### PR TITLE
Fix 'fmt' make command

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ cassettes: fmtcheck
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."
-	gofmt -w -s ./$(PKG_NAME)
+	gofmt -w -s .
 
 fmtcheck:
 	@./scripts/fmtcheck.sh

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
The gofmt command in the makefile was targeting a directory, but a formatting error existed outside that dir. This changes it to run against the project root.
