### PR TITLE
Use Upstream Import GPG action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
+        uses: crazy-max/ghaction-import-gpg@v5.0.0
+        with:
           GPG_PRIVATE_KEY: ${{ secrets.TERRAFORM_PROVIDER_GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.TERRAFORM_PROVIDER_GPG_PASSPHRASE }}
 


### PR DESCRIPTION
# Description

This PR updates the `goreleaser` action to use the upstream of `hashicorp/ghaction-import-gpg`. The new action is `crazy-max/ghaction-import-gpg@v5`.

See the following thread: https://github.com/hashicorp/ghaction-import-gpg/issues/11#issuecomment-1185107410