### PR TITLE
Skip ARM64 Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      - goos: windows
+        goarch: arm64
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
   - format: zip


### PR DESCRIPTION
# Description

This PR skips the build for a `windows/arm64` build. This build isn't possible in Go 1.16 as the windows/arm64 target wasn't added until [Go 1.17](https://go.dev/doc/go1.17#ports)