### PR TITLE
feat: read jupiterone_rule updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ for more details.
 provider_installation {
 
   # Use /home/developer/go/bin as an overridden package directory
-  # for the jupiterone/jupiterone provider. This disables the version and checksum
+  # for the jupiterone provider. This disables the version and checksum
   # verifications for this provider and forces Terraform to look for the
   # jupiterone provider plugin in the given directory.
   dev_overrides {
-    "jupiterone/jupiterone" = "/home/developer/go/bin"
+    "registry.terraform.io/hashicorp/jupiterone" = "/home/developer/go/bin"
   }
 
   # For all other providers, install them directly from their origin provider

--- a/README.md
+++ b/README.md
@@ -69,12 +69,15 @@ for more details.
 ```
 provider_installation {
 
-  # Use /home/developer/go/bin as an overridden package directory
+  # Use /home/$USER/go/bin as an overridden package directory
   # for the jupiterone provider. This disables the version and checksum
   # verifications for this provider and forces Terraform to look for the
   # jupiterone provider plugin in the given directory.
+
+  # Replace $USER with your username. On Mac and Linux systems this can be found
+  # through running "echo $USER" in your terminal.
   dev_overrides {
-    "registry.terraform.io/hashicorp/jupiterone" = "/home/developer/go/bin"
+    "registry.terraform.io/hashicorp/jupiterone" = "/home/$USER/go/bin"
   }
 
   # For all other providers, install them directly from their origin provider

--- a/jupiterone/cassettes/TestRuleInstance_Basic.yaml
+++ b/jupiterone/cassettes/TestRuleInstance_Basic.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"query":"\n\t\tmutation CreateQuestionRuleInstance ($instance: CreateQuestionRuleInstanceInput!) {\n\t\t\tcreateQuestionRuleInstance (\n\t\t\t\tinstance: $instance\n\t\t\t) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\tpollingInterval\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t}\n\t\t}\n\t","variables":{"instance":{"name":"tf-acc-test-3016486897996928385","description":"Test","specVersion":1,"pollingInterval":"ONE_DAY","outputs":["queries.query0.total","alertLevel"],"question":{"queries":[{"query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","name":"query0"}]},"templates":null,"operations":[{"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}],"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"}}]}}}
+      {"query":"\n\t\t\tmutation CreateQuestionRuleInstance ($instance: CreateInlineQuestionRuleInstanceInput!) {\n\t\t\t\tcreateQuestionRuleInstance: createInlineQuestionRuleInstance (\n\t\t\t\t\tinstance: $instance\n\t\t\t\t) {\n\t\t\t\t\tid\n\t\t\t\t\tname\n\t\t\t\t\tdescription\n\t\t\t\t\tversion\n\t\t\t\t\tspecVersion\n\t\t\t\t\tlatest\n\t\t\t\t\tdeleted\n\t\t\t\t\taccountId\n\t\t\t\t\ttype\n\t\t\t\t\tpollingInterval\n\t\t\t\t\ttemplates\n\t\t\t\t\tquestion {\n\t\t\t\t\t\tqueries {\n\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\tquery\n\t\t\t\t\t\t\tversion\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\toperations {\n\t\t\t\t\t\twhen\n\t\t\t\t\t\tactions\n\t\t\t\t\t}\n\t\t\t\t\toutputs\n\t\t\t\t\ttags\n\t\t\t\t}\n\t\t\t}\n\t\t","variables":{"instance":{"name":"tf-acc-test-5278254352274409628","description":"Test","specVersion":1,"pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     form: {}
     headers:
       Accept:
@@ -16,24 +16,61 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"createQuestionRuleInstance":{"id":"ec494bf0-9165-4463-b751-ec714a01539e","name":"tf-acc-test-3016486897996928385","description":"Test","version":1,"specVersion":1,"latest":true,"deleted":false,"accountId":"j1dev","type":"QUESTION","pollingInterval":"ONE_DAY","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"6ee204d1-c1c1-4800-a233-3a77f0f4cb92"},{"type":"CREATE_ALERT","id":"c93ebb58-8da5-4426-8b50-d73bac95964e"}]}],"outputs":["queries.query0.total","alertLevel"]}}}
+      {"data":{"createQuestionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":1,"specVersion":1,"latest":true,"deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"3fb15a9d-9fe4-4d85-a670-6587cbb76f7c"},{"type":"CREATE_ALERT","id":"4901c436-54e4-4dcd-9c28-b95a81db8406"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Content-Length:
-      - "823"
+      - "878"
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
+        data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src
+        ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
       Content-Type:
       - application/json
-      X-Amzn-Remapped-Content-Length:
-      - "823"
-      X-Amzn-Requestid:
-      - ea2ab7f3-08e5-4d30-b8eb-d674996d5b04
-      X-Amzn-Trace-Id:
-      - Root=1-5e95cb34-4d4b6ebeb1b60bea4760b258
+      Cross-Origin-Embedder-Policy:
+      - require-corp
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-origin
+      Expect-Ct:
+      - max-age=0
+      Origin-Agent-Cluster:
+      - ?1
+      Ratelimit-Limit:
+      - "1000"
+      Ratelimit-Remaining:
+      - "999"
+      Ratelimit-Requested:
+      - "1"
+      Ratelimit-Reset:
+      - "1"
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - "off"
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t}\n\t\t}\n\t","variables":{"id":"ec494bf0-9165-4463-b751-ec714a01539e"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
     form: {}
     headers:
       Accept:
@@ -46,24 +83,61 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"ec494bf0-9165-4463-b751-ec714a01539e","name":"tf-acc-test-3016486897996928385","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_DAY","deleted":false,"accountId":"j1dev","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"6ee204d1-c1c1-4800-a233-3a77f0f4cb92","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"c93ebb58-8da5-4426-8b50-d73bac95964e"}]}],"outputs":["queries.query0.total","alertLevel"]}}}
+      {"data":{"questionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"3fb15a9d-9fe4-4d85-a670-6587cbb76f7c","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"4901c436-54e4-4dcd-9c28-b95a81db8406"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Content-Length:
-      - "817"
+      - "872"
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
+        data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src
+        ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
       Content-Type:
       - application/json
-      X-Amzn-Remapped-Content-Length:
-      - "817"
-      X-Amzn-Requestid:
-      - 87899137-d5a6-4ec9-a59d-20bc4b6fb943
-      X-Amzn-Trace-Id:
-      - Root=1-5e95cb35-55fef8134eb041d338a7dd98
+      Cross-Origin-Embedder-Policy:
+      - require-corp
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-origin
+      Expect-Ct:
+      - max-age=0
+      Origin-Agent-Cluster:
+      - ?1
+      Ratelimit-Limit:
+      - "1000"
+      Ratelimit-Remaining:
+      - "999"
+      Ratelimit-Requested:
+      - "1"
+      Ratelimit-Reset:
+      - "1"
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - "off"
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t}\n\t\t}\n\t","variables":{"id":"ec494bf0-9165-4463-b751-ec714a01539e"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
     form: {}
     headers:
       Accept:
@@ -76,24 +150,61 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"ec494bf0-9165-4463-b751-ec714a01539e","name":"tf-acc-test-3016486897996928385","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_DAY","deleted":false,"accountId":"j1dev","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"6ee204d1-c1c1-4800-a233-3a77f0f4cb92","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"c93ebb58-8da5-4426-8b50-d73bac95964e"}]}],"outputs":["queries.query0.total","alertLevel"]}}}
+      {"data":{"questionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"3fb15a9d-9fe4-4d85-a670-6587cbb76f7c","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"4901c436-54e4-4dcd-9c28-b95a81db8406"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Content-Length:
-      - "817"
+      - "872"
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
+        data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src
+        ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
       Content-Type:
       - application/json
-      X-Amzn-Remapped-Content-Length:
-      - "817"
-      X-Amzn-Requestid:
-      - a93a5db7-7065-4d8f-b2ea-6981b5e7e596
-      X-Amzn-Trace-Id:
-      - Root=1-5e95cb35-860cca5c6217898a34a545c0
+      Cross-Origin-Embedder-Policy:
+      - require-corp
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-origin
+      Expect-Ct:
+      - max-age=0
+      Origin-Agent-Cluster:
+      - ?1
+      Ratelimit-Limit:
+      - "1000"
+      Ratelimit-Remaining:
+      - "999"
+      Ratelimit-Requested:
+      - "1"
+      Ratelimit-Reset:
+      - "1"
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - "off"
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t}\n\t\t}\n\t","variables":{"id":"ec494bf0-9165-4463-b751-ec714a01539e"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
     form: {}
     headers:
       Accept:
@@ -106,24 +217,61 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"ec494bf0-9165-4463-b751-ec714a01539e","name":"tf-acc-test-3016486897996928385","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_DAY","deleted":false,"accountId":"j1dev","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"6ee204d1-c1c1-4800-a233-3a77f0f4cb92","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"c93ebb58-8da5-4426-8b50-d73bac95964e"}]}],"outputs":["queries.query0.total","alertLevel"]}}}
+      {"data":{"questionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"3fb15a9d-9fe4-4d85-a670-6587cbb76f7c","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"4901c436-54e4-4dcd-9c28-b95a81db8406"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Content-Length:
-      - "817"
+      - "872"
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
+        data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src
+        ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
       Content-Type:
       - application/json
-      X-Amzn-Remapped-Content-Length:
-      - "817"
-      X-Amzn-Requestid:
-      - 078cb94d-836e-4a87-99dd-b99a05819584
-      X-Amzn-Trace-Id:
-      - Root=1-5e95cb35-b2302f08919f00854aa6a95a
+      Cross-Origin-Embedder-Policy:
+      - require-corp
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-origin
+      Expect-Ct:
+      - max-age=0
+      Origin-Agent-Cluster:
+      - ?1
+      Ratelimit-Limit:
+      - "1000"
+      Ratelimit-Remaining:
+      - "999"
+      Ratelimit-Requested:
+      - "1"
+      Ratelimit-Reset:
+      - "1"
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - "off"
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tmutation UpdateQuestionRuleInstance ($instance: UpdateQuestionRuleInstanceInput!) {\n\t\t\tupdateQuestionRuleInstance (\n\t\t\t\tinstance: $instance\n\t\t\t) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\tpollingInterval\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t}\n\t\t}\n\t","variables":{"instance":{"name":"tf-acc-test-3016486897996928385","description":"Test","specVersion":1,"pollingInterval":"ONE_DAY","outputs":["queries.query0.total","alertLevel"],"question":{"queries":[{"query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","name":"query0"}]},"templates":null,"id":"ec494bf0-9165-4463-b751-ec714a01539e","version":1,"operations":[{"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}]}}}
+      {"query":"\n\t\tmutation UpdateQuestionRuleInstance ($instance: UpdateInlineQuestionRuleInstanceInput!) {\n\t\t\t\tupdateQuestionRuleInstance: updateInlineQuestionRuleInstance (\n\t\t\t\t\tinstance: $instance\n\t\t\t\t) {\n\t\t\t\t\tid\n\t\t\t\t\tname\n\t\t\t\t\tdescription\n\t\t\t\t\tversion\n\t\t\t\t\tspecVersion\n\t\t\t\t\tlatest\n\t\t\t\t\tdeleted\n\t\t\t\t\taccountId\n\t\t\t\t\ttype\n\t\t\t\t\tpollingInterval\n\t\t\t\t\ttemplates\n\t\t\t\t\tquestion {\n\t\t\t\t\t\tqueries {\n\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\tquery\n\t\t\t\t\t\t\tversion\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\toperations {\n\t\t\t\t\t\twhen\n\t\t\t\t\t\tactions\n\t\t\t\t\t}\n\t\t\t\t\toutputs\n\t\t\t\t\ttags\n\t\t\t\t}\n\t\t\t}","variables":{"instance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":1,"specVersion":1,"pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     form: {}
     headers:
       Accept:
@@ -136,24 +284,61 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"updateQuestionRuleInstance":{"id":"ec494bf0-9165-4463-b751-ec714a01539e","name":"tf-acc-test-3016486897996928385","description":"Test","version":2,"specVersion":1,"latest":true,"deleted":false,"accountId":"j1dev","type":"QUESTION","pollingInterval":"ONE_DAY","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"a8985631-4693-4f60-a29e-55d07be83668"},{"type":"CREATE_ALERT","id":"4ba61239-d700-4fa9-a1ad-358955704558"}]}],"outputs":["queries.query0.total","alertLevel"]}}}
+      {"data":{"updateQuestionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":2,"specVersion":1,"latest":true,"deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"95c30b9c-0cf9-4d3e-8399-84cd4c780257"},{"type":"CREATE_ALERT","id":"70ae6f5c-00c9-47be-b85b-9a80870ed02a"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Content-Length:
-      - "750"
+      - "805"
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
+        data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src
+        ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
       Content-Type:
       - application/json
-      X-Amzn-Remapped-Content-Length:
-      - "750"
-      X-Amzn-Requestid:
-      - 400aed69-8e2c-48da-92d2-7a5ed71fecd7
-      X-Amzn-Trace-Id:
-      - Root=1-5e95cb35-e3e63af258ffc778e4f779f7
+      Cross-Origin-Embedder-Policy:
+      - require-corp
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-origin
+      Expect-Ct:
+      - max-age=0
+      Origin-Agent-Cluster:
+      - ?1
+      Ratelimit-Limit:
+      - "1000"
+      Ratelimit-Remaining:
+      - "999"
+      Ratelimit-Requested:
+      - "1"
+      Ratelimit-Reset:
+      - "1"
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - "off"
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t}\n\t\t}\n\t","variables":{"id":"ec494bf0-9165-4463-b751-ec714a01539e"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
     form: {}
     headers:
       Accept:
@@ -166,24 +351,61 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"ec494bf0-9165-4463-b751-ec714a01539e","name":"tf-acc-test-3016486897996928385","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_DAY","deleted":false,"accountId":"j1dev","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"a8985631-4693-4f60-a29e-55d07be83668","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"4ba61239-d700-4fa9-a1ad-358955704558"}]}],"outputs":["queries.query0.total","alertLevel"]}}}
+      {"data":{"questionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"95c30b9c-0cf9-4d3e-8399-84cd4c780257","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"70ae6f5c-00c9-47be-b85b-9a80870ed02a"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Content-Length:
-      - "744"
+      - "799"
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
+        data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src
+        ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
       Content-Type:
       - application/json
-      X-Amzn-Remapped-Content-Length:
-      - "744"
-      X-Amzn-Requestid:
-      - 96666e9d-d2ef-47d0-aa2e-2cb2ea712e3d
-      X-Amzn-Trace-Id:
-      - Root=1-5e95cb35-68d5c44a95230f780d36b513
+      Cross-Origin-Embedder-Policy:
+      - require-corp
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-origin
+      Expect-Ct:
+      - max-age=0
+      Origin-Agent-Cluster:
+      - ?1
+      Ratelimit-Limit:
+      - "1000"
+      Ratelimit-Remaining:
+      - "999"
+      Ratelimit-Requested:
+      - "1"
+      Ratelimit-Reset:
+      - "1"
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - "off"
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t}\n\t\t}\n\t","variables":{"id":"ec494bf0-9165-4463-b751-ec714a01539e"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
     form: {}
     headers:
       Accept:
@@ -196,24 +418,61 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"ec494bf0-9165-4463-b751-ec714a01539e","name":"tf-acc-test-3016486897996928385","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_DAY","deleted":false,"accountId":"j1dev","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"a8985631-4693-4f60-a29e-55d07be83668","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"4ba61239-d700-4fa9-a1ad-358955704558"}]}],"outputs":["queries.query0.total","alertLevel"]}}}
+      {"data":{"questionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"95c30b9c-0cf9-4d3e-8399-84cd4c780257","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"70ae6f5c-00c9-47be-b85b-9a80870ed02a"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Content-Length:
-      - "744"
+      - "799"
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
+        data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src
+        ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
       Content-Type:
       - application/json
-      X-Amzn-Remapped-Content-Length:
-      - "744"
-      X-Amzn-Requestid:
-      - 7699c967-476e-407c-a0e5-ca9cf6a22962
-      X-Amzn-Trace-Id:
-      - Root=1-5e95cb36-665d98c8b7397b2c3dd4e828
+      Cross-Origin-Embedder-Policy:
+      - require-corp
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-origin
+      Expect-Ct:
+      - max-age=0
+      Origin-Agent-Cluster:
+      - ?1
+      Ratelimit-Limit:
+      - "1000"
+      Ratelimit-Remaining:
+      - "999"
+      Ratelimit-Requested:
+      - "1"
+      Ratelimit-Reset:
+      - "1"
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - "off"
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t}\n\t\t}\n\t","variables":{"id":"ec494bf0-9165-4463-b751-ec714a01539e"}}
+      {"query":"\n\t\tmutation DeleteRuleInstance ($id: ID!) {\n\t\t\tdeleteRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t}\n\t      }\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
     form: {}
     headers:
       Accept:
@@ -226,54 +485,61 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"ec494bf0-9165-4463-b751-ec714a01539e","name":"tf-acc-test-3016486897996928385","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_DAY","deleted":false,"accountId":"j1dev","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"a8985631-4693-4f60-a29e-55d07be83668","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"4ba61239-d700-4fa9-a1ad-358955704558"}]}],"outputs":["queries.query0.total","alertLevel"]}}}
+      {"data":{"deleteRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}}
     headers:
-      Content-Length:
-      - "744"
-      Content-Type:
-      - application/json
-      X-Amzn-Remapped-Content-Length:
-      - "744"
-      X-Amzn-Requestid:
-      - 305d564b-8a05-4c42-b15c-d68823ee21fd
-      X-Amzn-Trace-Id:
-      - Root=1-5e95cb36-f6d214c5da5c2beb6c95911f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"query":"\n\t\tmutation DeleteRuleInstance ($id: ID!) {\n\t\t\tdeleteRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t}\n\t      }\n\t","variables":{"id":"ec494bf0-9165-4463-b751-ec714a01539e"}}
-    form: {}
-    headers:
-      Accept:
-      - application/json; charset=utf-8
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-    url: https://api.us.jupiterone.io/graphql
-    method: POST
-  response:
-    body: |
-      {"data":{"deleteRuleInstance":{"id":"ec494bf0-9165-4463-b751-ec714a01539e"}}}
-    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Content-Length:
       - "78"
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
+        data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src
+        ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
       Content-Type:
       - application/json
-      X-Amzn-Remapped-Content-Length:
-      - "78"
-      X-Amzn-Requestid:
-      - 2ff06315-095d-4879-8e8c-6ff9d92fb181
-      X-Amzn-Trace-Id:
-      - Root=1-5e95cb36-4b7bb0c835a08f3c5cb9e1ec
+      Cross-Origin-Embedder-Policy:
+      - require-corp
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-origin
+      Expect-Ct:
+      - max-age=0
+      Origin-Agent-Cluster:
+      - ?1
+      Ratelimit-Limit:
+      - "1000"
+      Ratelimit-Remaining:
+      - "999"
+      Ratelimit-Requested:
+      - "1"
+      Ratelimit-Reset:
+      - "1"
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - "off"
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t}\n\t\t}\n\t","variables":{"id":"ec494bf0-9165-4463-b751-ec714a01539e"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
     form: {}
     headers:
       Accept:
@@ -286,18 +552,55 @@ interactions:
     method: POST
   response:
     body: |
-      {"errors":[{"code":"INTERNAL_SERVER_ERROR","message":"Could not fetch rule instance. Rule instance does not exist.","locations":[{"line":2,"column":3}],"path":["questionRuleInstance"]}],"data":{"questionRuleInstance":null}}
+      {"errors":[{"message":"Could not fetch rule instance. Rule instance does not exist.","extensions":{"code":"INTERNAL_SERVER_ERROR","serviceName":"rules","exception":{"stacktrace":["Error: Could not fetch rule instance. Rule instance does not exist.","    at getQuestionRuleInstance (/var/task/index.js:1069318:13)","    at runMicrotasks (<anonymous>)","    at processTicksAndRejections (internal/process/task_queues.js:95:5)"],"message":"Could not fetch rule instance. Rule instance does not exist.","locations":[{"line":1,"column":50}],"path":["questionRuleInstance"]}}}],"data":{"questionRuleInstance":null}}
     headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Content-Length:
-      - "224"
+      - "610"
+      Content-Security-Policy:
+      - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
+        https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
+        data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src
+        ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
       Content-Type:
       - application/json
-      X-Amzn-Remapped-Content-Length:
-      - "224"
-      X-Amzn-Requestid:
-      - ded07460-0fb7-4d8d-ad32-a31f72293a3d
-      X-Amzn-Trace-Id:
-      - Root=1-5e95cb36-0f828107ed2afefbdf87f69b
+      Cross-Origin-Embedder-Policy:
+      - require-corp
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-origin
+      Expect-Ct:
+      - max-age=0
+      Origin-Agent-Cluster:
+      - ?1
+      Ratelimit-Limit:
+      - "1000"
+      Ratelimit-Remaining:
+      - "999"
+      Ratelimit-Requested:
+      - "1"
+      Ratelimit-Reset:
+      - "1"
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Dns-Prefetch-Control:
+      - "off"
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""

--- a/jupiterone/cassettes/TestRuleInstance_Basic.yaml
+++ b/jupiterone/cassettes/TestRuleInstance_Basic.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"query":"\n\t\t\tmutation CreateQuestionRuleInstance ($instance: CreateInlineQuestionRuleInstanceInput!) {\n\t\t\t\tcreateQuestionRuleInstance: createInlineQuestionRuleInstance (\n\t\t\t\t\tinstance: $instance\n\t\t\t\t) {\n\t\t\t\t\tid\n\t\t\t\t\tname\n\t\t\t\t\tdescription\n\t\t\t\t\tversion\n\t\t\t\t\tspecVersion\n\t\t\t\t\tlatest\n\t\t\t\t\tdeleted\n\t\t\t\t\taccountId\n\t\t\t\t\ttype\n\t\t\t\t\tpollingInterval\n\t\t\t\t\ttemplates\n\t\t\t\t\tquestion {\n\t\t\t\t\t\tqueries {\n\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\tquery\n\t\t\t\t\t\t\tversion\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\toperations {\n\t\t\t\t\t\twhen\n\t\t\t\t\t\tactions\n\t\t\t\t\t}\n\t\t\t\t\toutputs\n\t\t\t\t\ttags\n\t\t\t\t}\n\t\t\t}\n\t\t","variables":{"instance":{"name":"tf-acc-test-5278254352274409628","description":"Test","specVersion":1,"pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
+      {"query":"\n\t\t\tmutation CreateQuestionRuleInstance ($instance: CreateInlineQuestionRuleInstanceInput!) {\n\t\t\t\tcreateQuestionRuleInstance: createInlineQuestionRuleInstance (\n\t\t\t\t\tinstance: $instance\n\t\t\t\t) {\n\t\t\t\t\tid\n\t\t\t\t\tname\n\t\t\t\t\tdescription\n\t\t\t\t\tversion\n\t\t\t\t\tspecVersion\n\t\t\t\t\tlatest\n\t\t\t\t\tdeleted\n\t\t\t\t\taccountId\n\t\t\t\t\ttype\n\t\t\t\t\tpollingInterval\n\t\t\t\t\ttemplates\n\t\t\t\t\tquestion {\n\t\t\t\t\t\tqueries {\n\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\tquery\n\t\t\t\t\t\t\tversion\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\toperations {\n\t\t\t\t\t\twhen\n\t\t\t\t\t\tactions\n\t\t\t\t\t}\n\t\t\t\t\toutputs\n\t\t\t\t\ttags\n\t\t\t\t}\n\t\t\t}\n\t\t","variables":{"instance":{"name":"tf-provider-rule","description":"Test","specVersion":1,"pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     form: {}
     headers:
       Accept:
@@ -16,12 +16,12 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"createQuestionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":1,"specVersion":1,"latest":true,"deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"3fb15a9d-9fe4-4d85-a670-6587cbb76f7c"},{"type":"CREATE_ALERT","id":"4901c436-54e4-4dcd-9c28-b95a81db8406"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
+      {"data":{"createQuestionRuleInstance":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa","name":"tf-provider-rule","description":"Test","version":1,"specVersion":1,"latest":true,"deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"97ff6748-7ca3-4af6-8276-cb24a3948cd9"},{"type":"CREATE_ALERT","id":"d09b1286-820f-461f-b4a6-2eb46a2393ec"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
       Access-Control-Allow-Credentials:
       - "true"
       Content-Length:
-      - "878"
+      - "863"
       Content-Security-Policy:
       - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
         https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
@@ -70,7 +70,7 @@ interactions:
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa"}}
     form: {}
     headers:
       Accept:
@@ -83,12 +83,12 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"3fb15a9d-9fe4-4d85-a670-6587cbb76f7c","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"4901c436-54e4-4dcd-9c28-b95a81db8406"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
+      {"data":{"questionRuleInstance":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa","name":"tf-provider-rule","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"97ff6748-7ca3-4af6-8276-cb24a3948cd9","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"d09b1286-820f-461f-b4a6-2eb46a2393ec"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
       Access-Control-Allow-Credentials:
       - "true"
       Content-Length:
-      - "872"
+      - "857"
       Content-Security-Policy:
       - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
         https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
@@ -137,7 +137,7 @@ interactions:
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa"}}
     form: {}
     headers:
       Accept:
@@ -150,12 +150,12 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"3fb15a9d-9fe4-4d85-a670-6587cbb76f7c","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"4901c436-54e4-4dcd-9c28-b95a81db8406"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
+      {"data":{"questionRuleInstance":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa","name":"tf-provider-rule","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"97ff6748-7ca3-4af6-8276-cb24a3948cd9","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"d09b1286-820f-461f-b4a6-2eb46a2393ec"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
       Access-Control-Allow-Credentials:
       - "true"
       Content-Length:
-      - "872"
+      - "857"
       Content-Security-Policy:
       - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
         https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
@@ -204,7 +204,7 @@ interactions:
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa"}}
     form: {}
     headers:
       Accept:
@@ -217,12 +217,12 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"3fb15a9d-9fe4-4d85-a670-6587cbb76f7c","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"4901c436-54e4-4dcd-9c28-b95a81db8406"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
+      {"data":{"questionRuleInstance":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa","name":"tf-provider-rule","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"97ff6748-7ca3-4af6-8276-cb24a3948cd9","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"d09b1286-820f-461f-b4a6-2eb46a2393ec"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
       Access-Control-Allow-Credentials:
       - "true"
       Content-Length:
-      - "872"
+      - "857"
       Content-Security-Policy:
       - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
         https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
@@ -271,7 +271,7 @@ interactions:
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tmutation UpdateQuestionRuleInstance ($instance: UpdateInlineQuestionRuleInstanceInput!) {\n\t\t\t\tupdateQuestionRuleInstance: updateInlineQuestionRuleInstance (\n\t\t\t\t\tinstance: $instance\n\t\t\t\t) {\n\t\t\t\t\tid\n\t\t\t\t\tname\n\t\t\t\t\tdescription\n\t\t\t\t\tversion\n\t\t\t\t\tspecVersion\n\t\t\t\t\tlatest\n\t\t\t\t\tdeleted\n\t\t\t\t\taccountId\n\t\t\t\t\ttype\n\t\t\t\t\tpollingInterval\n\t\t\t\t\ttemplates\n\t\t\t\t\tquestion {\n\t\t\t\t\t\tqueries {\n\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\tquery\n\t\t\t\t\t\t\tversion\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\toperations {\n\t\t\t\t\t\twhen\n\t\t\t\t\t\tactions\n\t\t\t\t\t}\n\t\t\t\t\toutputs\n\t\t\t\t\ttags\n\t\t\t\t}\n\t\t\t}","variables":{"instance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":1,"specVersion":1,"pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
+      {"query":"\n\t\tmutation UpdateQuestionRuleInstance ($instance: UpdateInlineQuestionRuleInstanceInput!) {\n\t\t\t\tupdateQuestionRuleInstance: updateInlineQuestionRuleInstance (\n\t\t\t\t\tinstance: $instance\n\t\t\t\t) {\n\t\t\t\t\tid\n\t\t\t\t\tname\n\t\t\t\t\tdescription\n\t\t\t\t\tversion\n\t\t\t\t\tspecVersion\n\t\t\t\t\tlatest\n\t\t\t\t\tdeleted\n\t\t\t\t\taccountId\n\t\t\t\t\ttype\n\t\t\t\t\tpollingInterval\n\t\t\t\t\ttemplates\n\t\t\t\t\tquestion {\n\t\t\t\t\t\tqueries {\n\t\t\t\t\t\t\tname\n\t\t\t\t\t\t\tquery\n\t\t\t\t\t\t\tversion\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\toperations {\n\t\t\t\t\t\twhen\n\t\t\t\t\t\tactions\n\t\t\t\t\t}\n\t\t\t\t\toutputs\n\t\t\t\t\ttags\n\t\t\t\t}\n\t\t\t}\n\t\t","variables":{"instance":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa","name":"tf-provider-rule","description":"Test","version":1,"specVersion":1,"pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     form: {}
     headers:
       Accept:
@@ -284,12 +284,12 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"updateQuestionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":2,"specVersion":1,"latest":true,"deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"95c30b9c-0cf9-4d3e-8399-84cd4c780257"},{"type":"CREATE_ALERT","id":"70ae6f5c-00c9-47be-b85b-9a80870ed02a"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
+      {"data":{"updateQuestionRuleInstance":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa","name":"tf-provider-rule","description":"Test","version":2,"specVersion":1,"latest":true,"deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","pollingInterval":"ONE_WEEK","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"23552c21-8d46-48f1-ae7d-1ad42e628b39"},{"type":"CREATE_ALERT","id":"64baee15-496c-4fed-805b-5694bc45ce1d"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
       Access-Control-Allow-Credentials:
       - "true"
       Content-Length:
-      - "805"
+      - "790"
       Content-Security-Policy:
       - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
         https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
@@ -338,7 +338,7 @@ interactions:
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa"}}
     form: {}
     headers:
       Accept:
@@ -351,12 +351,12 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"95c30b9c-0cf9-4d3e-8399-84cd4c780257","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"70ae6f5c-00c9-47be-b85b-9a80870ed02a"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
+      {"data":{"questionRuleInstance":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa","name":"tf-provider-rule","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"23552c21-8d46-48f1-ae7d-1ad42e628b39","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"64baee15-496c-4fed-805b-5694bc45ce1d"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
       Access-Control-Allow-Credentials:
       - "true"
       Content-Length:
-      - "799"
+      - "784"
       Content-Security-Policy:
       - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
         https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
@@ -405,7 +405,7 @@ interactions:
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa"}}
     form: {}
     headers:
       Accept:
@@ -418,12 +418,12 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"questionRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362","name":"tf-acc-test-5278254352274409628","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"95c30b9c-0cf9-4d3e-8399-84cd4c780257","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"70ae6f5c-00c9-47be-b85b-9a80870ed02a"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
+      {"data":{"questionRuleInstance":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa","name":"tf-provider-rule","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"accountId":"1316127e-baf6-4c4a-bc01-4fbe9ddd3415","type":"QUESTION","templates":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1"}]},"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"23552c21-8d46-48f1-ae7d-1ad42e628b39","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"64baee15-496c-4fed-805b-5694bc45ce1d"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tag1","tag2"]}}}
     headers:
       Access-Control-Allow-Credentials:
       - "true"
       Content-Length:
-      - "799"
+      - "784"
       Content-Security-Policy:
       - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self''
         https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self''
@@ -472,7 +472,7 @@ interactions:
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tmutation DeleteRuleInstance ($id: ID!) {\n\t\t\tdeleteRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t}\n\t      }\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
+      {"query":"\n\t\tmutation DeleteRuleInstance ($id: ID!) {\n\t\t\tdeleteRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t}\n\t      }\n\t","variables":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa"}}
     form: {}
     headers:
       Accept:
@@ -485,7 +485,7 @@ interactions:
     method: POST
   response:
     body: |
-      {"data":{"deleteRuleInstance":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}}
+      {"data":{"deleteRuleInstance":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa"}}}
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -539,7 +539,7 @@ interactions:
     duration: ""
 - request:
     body: |
-      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"7060d853-bc73-4865-90a1-adab066f8362"}}
+      {"query":"\n\t\tquery GetQuestionRuleInstance($id: ID!) {\n\t\t\tquestionRuleInstance (id: $id) {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tdescription\n\t\t\t\tversion\n\t\t\t\tspecVersion\n\t\t\t\tlatest\n\t\t\t\tpollingInterval\n\t\t\t\tdeleted\n\t\t\t\taccountId\n\t\t\t\ttype\n\t\t\t\ttemplates\n\t\t\t\tquestion {\n\t\t\t\t\tqueries {\n\t\t\t\t\t\tname\n\t\t\t\t\t\tquery\n\t\t\t\t\t\tversion\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\toperations {\n\t\t\t\t\twhen\n\t\t\t\t\tactions\n\t\t\t\t}\n\t\t\t\toutputs\n\t\t\t\ttags\n\t\t\t}\n\t\t}\n\t","variables":{"id":"f2ad0219-549e-4f36-9569-35f8979c38fa"}}
     form: {}
     headers:
       Accept:

--- a/jupiterone/resource_rule.go
+++ b/jupiterone/resource_rule.go
@@ -227,12 +227,12 @@ func createQuestionRuleInstanceResource(_ context.Context, d *schema.ResourceDat
 }
 
 func resourceQuestionRuleInstanceUpdate(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	qri, err := newQuestionRuleInstance(d)
+	questionRuleInstance, err := newQuestionRuleInstance(d)
 	if err != nil {
 		return diag.Errorf("failed to build question rule instance: %s", err.Error())
 	}
 
-	updatedQuestionRuleInstance, err := m.(*ProviderConfiguration).Client.UpdateQuestionRuleInstance(qri)
+	updatedQuestionRuleInstance, err := m.(*ProviderConfiguration).Client.UpdateQuestionRuleInstance(questionRuleInstance)
 	if err != nil {
 		return diag.Errorf("failed to update question rule instance: %s", err.Error())
 	}
@@ -328,7 +328,7 @@ func resourceQuestionRuleInstanceRead(_ context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	d.SetId(d.Id())
+	d.SetId(questionRuleInstance.Id)
 	return nil
 }
 

--- a/jupiterone/resource_rule.go
+++ b/jupiterone/resource_rule.go
@@ -1,13 +1,14 @@
 package jupiterone
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/jupiterone/terraform-provider-jupiterone/jupiterone/internal/client"
-	"github.com/mitchellh/mapstructure"
 )
 
 const MIN_RULE_NAME_LENGTH = 1
@@ -17,7 +18,7 @@ func resourceQuestionRuleInstance() *schema.Resource {
 	var RulePollingIntervals = []string{"DISABLED", "THIRTY_MINUTES", "ONE_HOUR", "ONE_DAY", "ONE_WEEK"}
 
 	return &schema.Resource{
-		CreateContext: resourceQuestionRuleInstanceCreate,
+		CreateContext: createQuestionRuleInstanceResource,
 		ReadContext:   resourceQuestionRuleInstanceRead,
 		UpdateContext: resourceQuestionRuleInstanceUpdate,
 		DeleteContext: resourceQuestionRuleInstanceDelete,
@@ -25,7 +26,6 @@ func resourceQuestionRuleInstance() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				Description:  "Name of the rule, which is unique to each account.",
 				ValidateFunc: validation.StringLenBetween(MIN_RULE_NAME_LENGTH, MAX_RULE_NAME_LENGTH),
 			},
@@ -83,10 +83,11 @@ func resourceQuestionRuleInstance() *schema.Resource {
 				Deprecated:  "The question_name identifier is deprecated. Prefer to use a question's id property with question_id to reference a jupiterone_question in a jupiterone_rule.",
 			},
 			"operations": {
-				Type:         schema.TypeString,
-				Description:  "Actions that are executed when a corresponding condition is met.",
-				ValidateFunc: validation.StringIsJSON,
-				Required:     true,
+				Type:             schema.TypeString,
+				Description:      "Actions that are executed when a corresponding condition is met.",
+				ValidateFunc:     validation.StringIsJSON,
+				Required:         true,
+				DiffSuppressFunc: jsonDiffSuppressFunc,
 			},
 			"outputs": {
 				Type:        schema.TypeList,
@@ -137,9 +138,8 @@ func getQuestionQuerySchema() map[string]*schema.Schema {
 	}
 }
 
-func buildQuestionRuleInstanceProperties(d *schema.ResourceData) (*client.CommonQuestionRuleInstanceProperties, error) {
-	var questionRuleInstance client.CommonQuestionRuleInstanceProperties
-
+func newQuestionRuleInstance(d *schema.ResourceData) (*client.QuestionRuleInstance, error) {
+	questionRuleInstance := &client.QuestionRuleInstance{}
 	if v, ok := d.GetOk("name"); ok {
 		questionRuleInstance.Name = v.(string)
 	}
@@ -161,28 +161,30 @@ func buildQuestionRuleInstanceProperties(d *schema.ResourceData) (*client.Common
 	}
 
 	if v, ok := d.GetOk("operations"); ok {
-		questionRuleInstance.Operations = v.(string)
-	} else {
-		questionRuleInstance.Operations = "[]"
-	}
-
-	if v, ok := d.GetOk("question"); ok {
-		ruleQuestion, err := buildQuestionRuleInstanceQuestion(v.([]interface{}))
+		ops := make([]client.RuleOperation, 0)
+		err := json.Unmarshal([]byte(v.(string)), &ops)
 		if err != nil {
 			return nil, err
 		}
+		questionRuleInstance.Operations = ops
+	}
 
-		questionRuleInstance.Question = &(*ruleQuestion)[0]
+	if v, ok := d.GetOk("question"); ok {
+		v := v.([]interface{})
+		if len(v) == 0 {
+			questionRuleInstance.Question = map[string]interface{}{}
+		} else {
+			// Question MaxItems is 1. Enforced at schema level.
+			questionRuleInstance.Question = v[0].(map[string]interface{})
+		}
 	}
 
 	if v, ok := d.GetOk("question_id"); ok {
-		value := v.(string)
-		questionRuleInstance.QuestionId = &value
+		questionRuleInstance.QuestionId = v.(string)
 	}
 
 	if v, ok := d.GetOk("question_name"); ok {
-		value := v.(string)
-		questionRuleInstance.QuestionName = &value
+		questionRuleInstance.QuestionName = v.(string)
 	}
 
 	if v, ok := d.GetOk("templates"); ok {
@@ -193,36 +195,25 @@ func buildQuestionRuleInstanceProperties(d *schema.ResourceData) (*client.Common
 		questionRuleInstance.Tags = interfaceSliceToStringSlice(v.([]interface{}))
 	}
 
-	return &questionRuleInstance, nil
-}
-
-func buildQuestionRuleInstanceQuestion(terraformRuleQuestionList []interface{}) (*[]client.RuleQuestion, error) {
-	ruleQuestionList := make([]client.RuleQuestion, len(terraformRuleQuestionList))
-
-	for i, terraformRuleQuestion := range terraformRuleQuestionList {
-		var ruleQuestion client.RuleQuestion
-
-		if err := mapstructure.Decode(terraformRuleQuestion, &ruleQuestion); err != nil {
-			return nil, err
-		}
-
-		for i, query := range ruleQuestion.Queries {
-			ruleQuestion.Queries[i].Query = removeCRFromString(query.Query)
-		}
-
-		ruleQuestionList[i] = ruleQuestion
+	if v, ok := d.GetOk("version"); ok {
+		questionRuleInstance.Version = v.(int)
 	}
 
-	return &ruleQuestionList, nil
+	if d.Id() != "" {
+		questionRuleInstance.Id = d.Id()
+	}
+
+	return questionRuleInstance, nil
+
 }
 
-func resourceQuestionRuleInstanceCreate(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	questionRuleInstanceProperties, err := buildQuestionRuleInstanceProperties(d)
+func createQuestionRuleInstanceResource(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	questionRuleInstance, err := newQuestionRuleInstance(d)
 	if err != nil {
 		return diag.Errorf("failed to build question rule instance: %s", err.Error())
 	}
 
-	createdQuestion, err := m.(*ProviderConfiguration).Client.CreateQuestionRuleInstance(*questionRuleInstanceProperties)
+	createdQuestion, err := m.(*ProviderConfiguration).Client.CreateQuestionRuleInstance(*questionRuleInstance)
 	if err != nil {
 		return diag.Errorf("failed to create question rule instance: %s", err.Error())
 	}
@@ -236,29 +227,12 @@ func resourceQuestionRuleInstanceCreate(_ context.Context, d *schema.ResourceDat
 }
 
 func resourceQuestionRuleInstanceUpdate(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	questionRuleInstanceProperties, err := buildQuestionRuleInstanceProperties(d)
+	qri, err := newQuestionRuleInstance(d)
 	if err != nil {
 		return diag.Errorf("failed to build question rule instance: %s", err.Error())
 	}
 
-	var updateQuestionRuleInstanceProperties client.UpdateQuestionRuleInstanceProperties
-	updateQuestionRuleInstanceProperties.Id = d.Id()
-	updateQuestionRuleInstanceProperties.Name = questionRuleInstanceProperties.Name
-	updateQuestionRuleInstanceProperties.Description = questionRuleInstanceProperties.Description
-	updateQuestionRuleInstanceProperties.SpecVersion = questionRuleInstanceProperties.SpecVersion
-	updateQuestionRuleInstanceProperties.PollingInterval = questionRuleInstanceProperties.PollingInterval
-	updateQuestionRuleInstanceProperties.Operations = questionRuleInstanceProperties.Operations
-	updateQuestionRuleInstanceProperties.Outputs = questionRuleInstanceProperties.Outputs
-	updateQuestionRuleInstanceProperties.Question = questionRuleInstanceProperties.Question
-	updateQuestionRuleInstanceProperties.Templates = questionRuleInstanceProperties.Templates
-	updateQuestionRuleInstanceProperties.Tags = questionRuleInstanceProperties.Tags
-
-	if v, ok := d.GetOk("version"); ok {
-		updateQuestionRuleInstanceProperties.Version = v.(int)
-	}
-
-	updatedQuestionRuleInstance, err := m.(*ProviderConfiguration).Client.UpdateQuestionRuleInstance(updateQuestionRuleInstanceProperties)
-
+	updatedQuestionRuleInstance, err := m.(*ProviderConfiguration).Client.UpdateQuestionRuleInstance(qri)
 	if err != nil {
 		return diag.Errorf("failed to update question rule instance: %s", err.Error())
 	}
@@ -286,10 +260,85 @@ func resourceQuestionRuleInstanceRead(_ context.Context, d *schema.ResourceData,
 		return diag.Errorf("failed to read existing question rule instance: %s", err.Error())
 	}
 
-	if err := d.Set("version", questionRuleInstance.Version); err != nil {
+	err = d.Set("name", questionRuleInstance.Name)
+	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	d.SetId(questionRuleInstance.Id)
+	err = d.Set("description", questionRuleInstance.Description)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("version", questionRuleInstance.Version)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("polling_interval", questionRuleInstance.PollingInterval)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("templates", questionRuleInstance.Templates)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	questionSlice := []map[string]interface{}{questionRuleInstance.Question}
+	err = d.Set("question", questionSlice)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("question_id", questionRuleInstance.QuestionId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("question_name", questionRuleInstance.QuestionName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Because we store the Operations as a raw string. The id property, which
+	// is set after the creation of the question creates a diff that would cause
+	// the Operations to update on every terraform apply
+	for _, op := range questionRuleInstance.Operations {
+		for _, action := range op.Actions {
+			delete(action, "id")
+		}
+	}
+
+	ops, err := operationsToJSONString(questionRuleInstance.Operations)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("operations", ops)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("outputs", questionRuleInstance.Outputs)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("tags", questionRuleInstance.Tags)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Id())
 	return nil
+}
+
+func operationsToJSONString(ops []client.RuleOperation) (string, error) {
+	buf := new(bytes.Buffer)
+	encoder := json.NewEncoder(buf)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(ops)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }

--- a/jupiterone/resource_rule_test.go
+++ b/jupiterone/resource_rule_test.go
@@ -19,7 +19,7 @@ func TestRuleInstance_Basic(t *testing.T) {
 	accProviders, cleanup := testAccProviders(t)
 	defer cleanup(t)
 	accProvider := testAccProvider(t, accProviders)
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	ruleName := "tf-provider-rule"
 	resourceName := "jupiterone_rule.test"
 
 	operations := getValidOperations()
@@ -30,15 +30,15 @@ func TestRuleInstance_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    accProviders,
-		CheckDestroy: testAccCheckRuleInstanceDestroy(ctx, accProvider),
+		CheckDestroy: testAccCheckRuleInstanceDestroy(ctx, resourceName, accProvider),
 		Steps: []resource.TestStep{
 			{
-				Config: testRuleInstanceBasicConfigWithOperations(rName, operations),
+				Config: testRuleInstanceBasicConfigWithOperations(ruleName, operations),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRuleExists(ctx, accProvider),
+					testAccCheckRuleExists(ctx, resourceName, accProvider),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "version", "1"),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test"),
 					resource.TestCheckResourceAttr(resourceName, "spec_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "polling_interval", "ONE_WEEK"),
@@ -57,12 +57,12 @@ func TestRuleInstance_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testRuleInstanceBasicConfigWithOperations(rName, operationsUpdate),
+				Config: testRuleInstanceBasicConfigWithOperations(ruleName, operationsUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRuleExists(ctx, accProvider),
+					testAccCheckRuleExists(ctx, resourceName, accProvider),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test"),
 					resource.TestCheckResourceAttr(resourceName, "spec_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "polling_interval", "ONE_WEEK"),
@@ -90,11 +90,12 @@ func TestRuleInstance_Config_Errors(t *testing.T) {
 	accProvider := testAccProvider(t, accProviders)
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	ctx := context.Background()
+	resourceName := "jupiterone_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    accProviders,
-		CheckDestroy: testAccCheckRuleInstanceDestroy(ctx, accProvider),
+		CheckDestroy: testAccCheckRuleInstanceDestroy(ctx, resourceName, accProvider),
 		Steps: []resource.TestStep{
 			{
 				Config:      testRuleInstanceBasicConfigWithOperations(rName, "not json"),
@@ -120,75 +121,72 @@ func getValidOperationsWithoutConditions() string {
 	return `[{"actions":[{"targetValue":"HIGH","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT"}]}]`
 }
 
-func testAccCheckRuleExists(ctx context.Context, accProvider *schema.Provider) resource.TestCheckFunc {
+func testAccCheckRuleExists(ctx context.Context, ruleName string, accProvider *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		resource := s.RootModule().Resources[ruleName]
 		providerConf := accProvider.Meta().(*ProviderConfiguration)
 		client := providerConf.Client
 
-		if err := ruleExistsHelper(ctx, s, client); err != nil {
+		err := ruleExistsHelper(ctx, resource.Primary.ID, client)
+		if err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func ruleExistsHelper(ctx context.Context, s *terraform.State, client *client.JupiterOneClient) error {
-	for _, r := range s.RootModule().Resources {
-		err := resource.RetryContext(ctx, 10*time.Second, func() *resource.RetryError {
-			id := r.Primary.ID
-			ruleInstance, err := client.GetQuestionRuleInstanceByID(id)
+func ruleExistsHelper(ctx context.Context, id string, client *client.JupiterOneClient) error {
+	err := resource.RetryContext(ctx, 10*time.Second, func() *resource.RetryError {
+		ruleInstance, err := client.GetQuestionRuleInstanceByID(id)
 
-			if ruleInstance != nil {
-				return nil
-			}
-
-			if err != nil && strings.Contains(err.Error(), "Rule instance does not exist.") {
-				return resource.RetryableError(fmt.Errorf("Rule instance does not exist (id=%q)", id))
-			}
-
-			return resource.NonRetryableError(err)
-		})
-
-		if err != nil {
-			return err
+		if ruleInstance != nil {
+			return nil
 		}
+
+		if err != nil && strings.Contains(err.Error(), "Rule instance does not exist.") {
+			return resource.RetryableError(fmt.Errorf("Rule instance does not exist (id=%q)", id))
+		}
+
+		return resource.NonRetryableError(err)
+	})
+
+	if err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func testAccCheckRuleInstanceDestroy(ctx context.Context, accProvider *schema.Provider) func(*terraform.State) error {
+func testAccCheckRuleInstanceDestroy(ctx context.Context, resourceName string, accProvider *schema.Provider) func(*terraform.State) error {
 	return func(s *terraform.State) error {
+		resource := s.RootModule().Resources[resourceName]
 		providerConf := accProvider.Meta().(*ProviderConfiguration)
 		client := providerConf.Client
 
-		if err := ruleInstanceDestroyHelper(ctx, s, client); err != nil {
+		if err := ruleInstanceDestroyHelper(ctx, resource.Primary.ID, client); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func ruleInstanceDestroyHelper(ctx context.Context, s *terraform.State, client *client.JupiterOneClient) error {
-	for _, r := range s.RootModule().Resources {
-		err := resource.RetryContext(ctx, 30*time.Second, func() *resource.RetryError {
-			id := r.Primary.ID
-			ruleInstance, err := client.GetQuestionRuleInstanceByID(id)
+func ruleInstanceDestroyHelper(ctx context.Context, id string, client *client.JupiterOneClient) error {
+	err := resource.RetryContext(ctx, 30*time.Second, func() *resource.RetryError {
+		ruleInstance, err := client.GetQuestionRuleInstanceByID(id)
 
-			if ruleInstance != nil {
-				return resource.RetryableError(fmt.Errorf("Rule instance still exists (id=%q)", id))
-			}
-
-			if err != nil && strings.Contains(err.Error(), "Rule instance does not exist.") {
-				return nil
-			}
-
-			return resource.NonRetryableError(err)
-		})
-
-		if err != nil {
-			return err
+		if ruleInstance != nil {
+			return resource.RetryableError(fmt.Errorf("Rule instance still exists (id=%q)", id))
 		}
+
+		if err != nil && strings.Contains(err.Error(), "Rule instance does not exist.") {
+			return nil
+		}
+
+		return resource.NonRetryableError(err)
+	})
+
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/jupiterone/resource_rule_test.go
+++ b/jupiterone/resource_rule_test.go
@@ -41,7 +41,7 @@ func TestRuleInstance_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test"),
 					resource.TestCheckResourceAttr(resourceName, "spec_version", "1"),
-					resource.TestCheckResourceAttr(resourceName, "polling_interval", "ONE_DAY"),
+					resource.TestCheckResourceAttr(resourceName, "polling_interval", "ONE_WEEK"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2"),
@@ -65,7 +65,7 @@ func TestRuleInstance_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test"),
 					resource.TestCheckResourceAttr(resourceName, "spec_version", "1"),
-					resource.TestCheckResourceAttr(resourceName, "polling_interval", "ONE_DAY"),
+					resource.TestCheckResourceAttr(resourceName, "polling_interval", "ONE_WEEK"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2"),
@@ -200,7 +200,7 @@ func testRuleInstanceBasicConfigWithOperations(rName string, operations string) 
 			name = %q
 			description = "Test"
 			spec_version = 1
-			polling_interval = "ONE_DAY"
+			polling_interval = "ONE_WEEK"
 			tags = ["tag1","tag2"]
 
 			question {

--- a/jupiterone/util.go
+++ b/jupiterone/util.go
@@ -24,14 +24,17 @@ func interfaceSliceToStringSlice(l []interface{}) []string {
 
 func jsonDiffSuppressFunc(k, oldValue, newValue string, d *schema.ResourceData) bool {
 	var old, new interface{}
+	// Errors during json.Unmarshal likely mean that newValue is empty or deleted.
+	// In this case we shouldn't suppress the diff and let downstream code
+	// handle the changes and updates.
 	err := json.Unmarshal([]byte(oldValue), &old)
 	if err != nil {
-		panic(err)
+		return false
 	}
 
 	err = json.Unmarshal([]byte(newValue), &new)
 	if err != nil {
-		panic(err)
+		return false
 	}
 
 	return reflect.DeepEqual(old, new)

--- a/jupiterone/util.go
+++ b/jupiterone/util.go
@@ -1,6 +1,12 @@
 package jupiterone
 
-import "strings"
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
 
 func removeCRFromString(s string) string {
 	return strings.ReplaceAll(s, "\r", "")
@@ -14,4 +20,19 @@ func interfaceSliceToStringSlice(l []interface{}) []string {
 	}
 
 	return ret
+}
+
+func jsonDiffSuppressFunc(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	var old, new interface{}
+	err := json.Unmarshal([]byte(oldValue), &old)
+	if err != nil {
+		panic(err)
+	}
+
+	err = json.Unmarshal([]byte(newValue), &new)
+	if err != nil {
+		panic(err)
+	}
+
+	return reflect.DeepEqual(old, new)
 }


### PR DESCRIPTION
This commit refactors the create, update, and read functions
for the `jupiterone_rule`. They now use a unified QuestionRuleInstance
type in all three operations.

Several changes with types had to occur to properly read updates
and compare them versus the terraform state. One such change is the
introduction of jsonDiffSupressFunc for `operations` as well as
stripping `ids` from the `action` portion of `operations`.

The integration test has passed and a new recording is commited.
I plan to add aditional tests to verify my changes work. I have
performed significant manual testing.
