### PR TITLE
Implement import for questions and rules

### DIFF
--- a/jupiterone/cassettes/TestInlineRuleInstance_BasicImport.yaml
+++ b/jupiterone/cassettes/TestInlineRuleInstance_BasicImport.yaml
@@ -1,0 +1,159 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 933
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation CreateInlineQuestionRuleInstance ($instance: CreateInlineQuestionRuleInstanceInput!) {\n\tcreateQuestionRuleInstance: createInlineQuestionRuleInstance(instance: $instance) {\n\t\tid\n\t\tversion\n\t\tspecVersion\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t}\n}\n","variables":{"instance":{"question":{"queries":[{"query":"Find DataStore with classification=(''critical'' or ''sensitive'' or ''confidential'' or ''restricted'') and encrypted!=true","name":"query0","version":"v1","includeDeleted":false}]},"templates":null,"tags":["tf_acc:1","tf_acc:2"],"name":"tf-provider-test-rule","description":"test","specVersion":1,"operations":[],"outputs":["queries.query0.total","alertLevel"],"pollingInterval":"ONE_DAY","notifyOnFailure":false}},"operationName":"CreateInlineQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 338
+        uncompressed: false
+        body: |
+            {"data":{"createQuestionRuleInstance":{"id":"864c6ba4-c72b-496f-aaf6-04bc671224ac","version":1,"specVersion":1,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false}]},"operations":[]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "338"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 1.008771542s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 568
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionRuleInstance ($id: ID!) {\n\tquestionRuleInstance(id: $id) {\n\t\tid\n\t\tname\n\t\tdescription\n\t\tversion\n\t\tspecVersion\n\t\tlatest\n\t\tpollingInterval\n\t\tdeleted\n\t\ttype\n\t\ttemplates\n\t\tnotifyOnFailure\n\t\tquestionId\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t\toutputs\n\t\ttags\n\t}\n}\n","variables":{"id":"864c6ba4-c72b-496f-aaf6-04bc671224ac"},"operationName":"GetQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 598
+        uncompressed: false
+        body: |
+            {"data":{"questionRuleInstance":{"id":"864c6ba4-c72b-496f-aaf6-04bc671224ac","name":"tf-provider-test-rule","description":"test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_DAY","deleted":false,"type":"QUESTION","templates":null,"notifyOnFailure":false,"questionId":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false}]},"operations":[],"outputs":["queries.query0.total","alertLevel"],"tags":["tf_acc:1","tf_acc:2"]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "598"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 719.60225ms

--- a/jupiterone/cassettes/TestQuestion_BasicImport.yaml
+++ b/jupiterone/cassettes/TestQuestion_BasicImport.yaml
@@ -1,0 +1,159 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 574
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation CreateQuestion ($question: CreateQuestionInput!) {\n\tcreateQuestion(question: $question) {\n\t\tid\n\t}\n}\n","variables":{"question":{"title":"tf-provider-test-question","name":"","tags":["tf_acc:1"],"description":"test","showTrend":false,"pollingInterval":"ONE_DAY","queries":[{"query":"Find DataStore with classification=(''critical'' or ''sensitive'' or ''confidential'' or ''restricted'') and encrypted!=true","version":"v1","name":"query0","resultsAre":"BAD","includeDeleted":false}],"compliance":null,"variables":null}},"operationName":"CreateQuestion"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 74
+        uncompressed: false
+        body: |
+            {"data":{"createQuestion":{"id":"1ef6c772-92ce-44df-b23d-78c549ee2ec1"}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "74"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 980.647417ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 419
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"1ef6c772-92ce-44df-b23d-78c549ee2ec1"},"operationName":"GetQuestionById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 405
+        uncompressed: false
+        body: |
+            {"data":{"question":{"id":"1ef6c772-92ce-44df-b23d-78c549ee2ec1","title":"tf-provider-test-question","description":"test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"BAD"}],"tags":["tf_acc:1"],"compliance":null}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "405"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 889.086ms

--- a/jupiterone/resource_question.go
+++ b/jupiterone/resource_question.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -27,6 +28,7 @@ var QueryResultsAre = []string{
 // Ensure provider defined types fully satisfy framework interfaces
 var _ resource.Resource = &QuestionResource{}
 var _ resource.ResourceWithConfigure = &QuestionResource{}
+var _ resource.ResourceWithImportState = &QuestionResource{}
 
 type QuestionResource struct {
 	version string
@@ -289,6 +291,11 @@ func (r *QuestionResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// ImportState implements resource.ResourceWithImportState
+func (*QuestionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 // Update implements resource.Resource

--- a/jupiterone/resource_question_test.go
+++ b/jupiterone/resource_question_test.go
@@ -20,18 +20,18 @@ func TestQuestion_Basic(t *testing.T) {
 	defer cleanup(t)
 
 	resourceName := "jupiterone_question.test"
-	questionName := "tf-provider-test-question"
+	questionTitle := "tf-provider-test-question"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(recordingClient),
 		CheckDestroy:             testAccCheckQuestionDestroy(ctx, directClient),
 		Steps: []resource.TestStep{
 			{
-				Config: testQuestionBasicConfigWithTags(questionName, "tf_acc:1"),
+				Config: testQuestionBasicConfigWithTags(questionTitle, "tf_acc:1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckQuestionExists(ctx, directClient),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "title", questionName),
+					resource.TestCheckResourceAttr(resourceName, "title", questionTitle),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tf_acc:1"),
@@ -42,11 +42,11 @@ func TestQuestion_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testQuestionBasicConfigWithTags(questionName, "tf_acc:2"),
+				Config: testQuestionBasicConfigWithTags(questionTitle, "tf_acc:2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckQuestionExists(ctx, directClient),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "title", questionName),
+					resource.TestCheckResourceAttr(resourceName, "title", questionTitle),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tf_acc:2"),
@@ -58,6 +58,68 @@ func TestQuestion_Basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestQuestion_BasicImport(t *testing.T) {
+	ctx := context.TODO()
+
+	recordingClient, directClient, cleanup := setupTestClients(ctx, t)
+	defer cleanup(t)
+
+	resourceName := "jupiterone_question.test"
+	questionTitle := "tf-provider-test-question"
+	questionTags := []string{"tf_acc:1"}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(recordingClient),
+		CheckDestroy:             testAccCheckQuestionDestroy(ctx, directClient),
+		Steps: []resource.TestStep{
+			{
+				ImportState:   true,
+				ResourceName:  resourceName,
+				ImportStateId: createTestQuestion(ctx, t, recordingClient, questionTitle, questionTags),
+				Config:        testQuestionBasicConfigWithTags(questionTitle, questionTags[0]),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQuestionExists(ctx, directClient),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "title", questionTitle),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "tf_acc:1"),
+					resource.TestCheckResourceAttr(resourceName, "query.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "query.0.name", "query0"),
+					resource.TestCheckResourceAttr(resourceName, "query.0.version", "v1"),
+					resource.TestCheckResourceAttr(resourceName, "query.0.query", "Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true"),
+				),
+			},
+		},
+	})
+}
+
+// createTestQuestion directly calls the client to create a question directly
+// for import or other tests. Because the id must be returned, this must
+// called with the recorder client.
+func createTestQuestion(ctx context.Context, t *testing.T, qlient graphql.Client, title string, tags []string) string {
+	r, err := client.CreateQuestion(ctx, qlient, client.CreateQuestionInput{
+		Title:           title,
+		Description:     "test",
+		Tags:            tags,
+		PollingInterval: client.SchedulerPollingIntervalOneDay,
+		Queries: []client.QuestionQueryInput{
+			{
+				Name:       "query0",
+				Query:      "Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true",
+				Version:    "v1",
+				ResultsAre: client.QueryResultsAreBad,
+			},
+		},
+	})
+	if err != nil {
+		t.Log("error creating question for import test", err)
+		t.FailNow()
+	}
+
+	return r.CreateQuestion.Id
 }
 
 func testAccCheckQuestionExists(ctx context.Context, qlient graphql.Client) resource.TestCheckFunc {


### PR DESCRIPTION
This PR implements support for `terraform import` for rules and questions.

Some of the fields that are filled in by the provider have been changed from `string` to the terraform `types.String`. This values will still be validated and follow the existing constraints, so there shouldn't be any change to usage.