### PR TITLE
Fix `scope_filter` planning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 terraform-provider-jupiterone
+dist/
 *.dll
 *.exe
 .DS_Store

--- a/docs/resources/rule.md
+++ b/docs/resources/rule.md
@@ -114,10 +114,10 @@ resource "jupiterone_rule" "users_without_mfa" {
 - `polling_interval` (String) Frequency of automated rule evaluation. Defaults to ONE_DAY.
 - `question` (Block List) Contains properties related to queries used in the rule evaluation. (see [below for nested schema](#nestedblock--question))
 - `question_id` (String) Specifies the ID of a question to be used in rule evaluation.
-- `question_name` (String, Deprecated) Specifies the name of a question to be used in rule evaluation.
 - `spec_version` (Number) Rule evaluation specification version in the case of breaking changes.
 - `tags` (List of String) Comma separated list of tags to apply to the rule.
 - `templates` (Map of String) Optional key/value pairs of template name to template
+- `trigger_on_new_only` (Boolean)
 
 ### Read-Only
 

--- a/jupiterone/cassettes/TestFrameworkItem_Basic.yaml
+++ b/jupiterone/cassettes/TestFrameworkItem_Basic.yaml
@@ -30,7 +30,7 @@ interactions:
         content_length: 85
         uncompressed: false
         body: |
-            {"data":{"createComplianceFramework":{"id":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"}}}
+            {"data":{"createComplianceFramework":{"id":"fa03a945-249f-49f7-99bd-090391f313f1"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -78,7 +78,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.01395275s
+        duration: 748.009542ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation CreateComplianceGroup ($input: CreateComplianceGroupInput!) {\n\tcreateComplianceGroup(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}},"operationName":"CreateComplianceGroup"}'
+        body: '{"query":"\nmutation CreateComplianceGroup ($input: CreateComplianceGroupInput!) {\n\tcreateComplianceGroup(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}},"operationName":"CreateComplianceGroup"}'
         form: {}
         headers:
             Cache-Control:
@@ -108,7 +108,7 @@ interactions:
         content_length: 81
         uncompressed: false
         body: |
-            {"data":{"createComplianceGroup":{"id":"742249c5-f37f-4363-b498-1a5258878cf5"}}}
+            {"data":{"createComplianceGroup":{"id":"a740f331-5775-4e21-9e72-094d08e874f1"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -156,7 +156,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 809.792041ms
+        duration: 849.110709ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation CreateComplianceFrameworkItem ($input: CreateComplianceFrameworkItemInput!) {\n\tcreateComplianceFrameworkItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"name":"tf-provider-acc test FrameworkItem","description":"","displayCategory":"","ref":"test-requirement-1","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","webLink":""}},"operationName":"CreateComplianceFrameworkItem"}'
+        body: '{"query":"\nmutation CreateComplianceFrameworkItem ($input: CreateComplianceFrameworkItemInput!) {\n\tcreateComplianceFrameworkItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"name":"tf-provider-acc test FrameworkItem","description":"","displayCategory":"","ref":"test-requirement-1","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","webLink":""}},"operationName":"CreateComplianceFrameworkItem"}'
         form: {}
         headers:
             Cache-Control:
@@ -186,7 +186,7 @@ interactions:
         content_length: 89
         uncompressed: false
         body: |
-            {"data":{"createComplianceFrameworkItem":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"}}}
+            {"data":{"createComplianceFrameworkItem":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -234,7 +234,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 885.678542ms
+        duration: 769.766625ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -246,7 +246,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -264,7 +264,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -312,7 +312,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 415.190583ms
+        duration: 430.977ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -324,7 +324,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -342,7 +342,7 @@ interactions:
         content_length: 346
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"742249c5-f37f-4363-b498-1a5258878cf5","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"a740f331-5775-4e21-9e72-094d08e874f1","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -390,7 +390,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 828.799583ms
+        duration: 690.01425ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -402,7 +402,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"},"operationName":"GetComplianceFrameworkItemById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"},"operationName":"GetComplianceFrameworkItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -420,7 +420,7 @@ interactions:
         content_length: 265
         uncompressed: false
         body: |
-            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc test FrameworkItem","description":"","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","displayCategory":"","ref":"test-requirement-1","webLink":null}}}
+            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc test FrameworkItem","description":"","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","displayCategory":"","ref":"test-requirement-1","webLink":null}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -468,7 +468,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 707.8385ms
+        duration: 694.826791ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -480,7 +480,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -498,7 +498,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -546,7 +546,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 410.24825ms
+        duration: 397.268125ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -558,7 +558,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -576,7 +576,7 @@ interactions:
         content_length: 346
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"742249c5-f37f-4363-b498-1a5258878cf5","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"a740f331-5775-4e21-9e72-094d08e874f1","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -624,7 +624,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 993.957792ms
+        duration: 763.263792ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -636,7 +636,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"},"operationName":"GetComplianceFrameworkItemById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"},"operationName":"GetComplianceFrameworkItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -654,7 +654,7 @@ interactions:
         content_length: 265
         uncompressed: false
         body: |
-            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc test FrameworkItem","description":"","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","displayCategory":"","ref":"test-requirement-1","webLink":null}}}
+            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc test FrameworkItem","description":"","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","displayCategory":"","ref":"test-requirement-1","webLink":null}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -702,7 +702,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.06222725s
+        duration: 627.187417ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -714,7 +714,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation UpdateComplianceFrameworkItem ($input: UpdateComplianceFrameworkItemInput!) {\n\tupdateComplianceFrameworkItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe","updates":{"name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test framework item","displayCategory":"second","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceFrameworkItem"}'
+        body: '{"query":"\nmutation UpdateComplianceFrameworkItem ($input: UpdateComplianceFrameworkItemInput!) {\n\tupdateComplianceFrameworkItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162","updates":{"name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test framework item","displayCategory":"second","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceFrameworkItem"}'
         form: {}
         headers:
             Cache-Control:
@@ -732,7 +732,7 @@ interactions:
         content_length: 89
         uncompressed: false
         body: |
-            {"data":{"updateComplianceFrameworkItem":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"}}}
+            {"data":{"updateComplianceFrameworkItem":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -780,7 +780,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 623.945084ms
+        duration: 727.878542ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -810,7 +810,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -858,7 +858,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 416.276333ms
+        duration: 387.080708ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -870,7 +870,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -888,7 +888,7 @@ interactions:
         content_length: 346
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"742249c5-f37f-4363-b498-1a5258878cf5","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"a740f331-5775-4e21-9e72-094d08e874f1","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -936,7 +936,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 633.993833ms
+        duration: 716.724541ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -948,7 +948,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"},"operationName":"GetComplianceFrameworkItemById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"},"operationName":"GetComplianceFrameworkItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -966,7 +966,7 @@ interactions:
         content_length: 379
         uncompressed: false
         body: |
-            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test framework item","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","displayCategory":"second","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}}
+            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test framework item","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","displayCategory":"second","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1014,7 +1014,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 759.90725ms
+        duration: 1.047659958s
     - id: 13
       request:
         proto: HTTP/1.1
@@ -1026,7 +1026,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -1044,7 +1044,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1092,7 +1092,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 435.879084ms
+        duration: 401.195208ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -1122,7 +1122,7 @@ interactions:
         content_length: 346
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"742249c5-f37f-4363-b498-1a5258878cf5","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"a740f331-5775-4e21-9e72-094d08e874f1","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1170,7 +1170,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 592.628416ms
+        duration: 721.660208ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1182,7 +1182,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"},"operationName":"GetComplianceFrameworkItemById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"},"operationName":"GetComplianceFrameworkItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -1200,7 +1200,7 @@ interactions:
         content_length: 379
         uncompressed: false
         body: |
-            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test framework item","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","displayCategory":"second","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}}
+            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test framework item","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","displayCategory":"second","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1248,7 +1248,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 657.546958ms
+        duration: 647.388ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -1260,7 +1260,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation UpdateComplianceFrameworkItem ($input: UpdateComplianceFrameworkItemInput!) {\n\tupdateComplianceFrameworkItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe","updates":{"name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test framework item","displayCategory":"second","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceFrameworkItem"}'
+        body: '{"query":"\nmutation UpdateComplianceFrameworkItem ($input: UpdateComplianceFrameworkItemInput!) {\n\tupdateComplianceFrameworkItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162","updates":{"name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test framework item","displayCategory":"second","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceFrameworkItem"}'
         form: {}
         headers:
             Cache-Control:
@@ -1278,7 +1278,7 @@ interactions:
         content_length: 89
         uncompressed: false
         body: |
-            {"data":{"updateComplianceFrameworkItem":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"}}}
+            {"data":{"updateComplianceFrameworkItem":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1326,7 +1326,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 910.225417ms
+        duration: 779.856166ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1338,7 +1338,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -1356,7 +1356,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1404,7 +1404,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 379.353042ms
+        duration: 1.644501834s
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1416,7 +1416,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -1434,7 +1434,7 @@ interactions:
         content_length: 346
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"742249c5-f37f-4363-b498-1a5258878cf5","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"a740f331-5775-4e21-9e72-094d08e874f1","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1482,7 +1482,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 665.834709ms
+        duration: 2.150533292s
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1494,7 +1494,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"},"operationName":"GetComplianceFrameworkItemById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"},"operationName":"GetComplianceFrameworkItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -1512,7 +1512,7 @@ interactions:
         content_length: 378
         uncompressed: false
         body: |
-            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test framework item","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","displayCategory":"second","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}}
+            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test framework item","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","displayCategory":"second","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1560,7 +1560,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 672.455834ms
+        duration: 1.1783215s
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1572,7 +1572,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -1590,7 +1590,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1638,7 +1638,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 350.151ms
+        duration: 491.963667ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -1650,7 +1650,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -1668,7 +1668,7 @@ interactions:
         content_length: 346
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"742249c5-f37f-4363-b498-1a5258878cf5","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"a740f331-5775-4e21-9e72-094d08e874f1","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1716,7 +1716,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 696.075375ms
+        duration: 736.875291ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1728,7 +1728,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"},"operationName":"GetComplianceFrameworkItemById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"},"operationName":"GetComplianceFrameworkItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -1746,7 +1746,7 @@ interactions:
         content_length: 378
         uncompressed: false
         body: |
-            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test framework item","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","displayCategory":"second","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}}
+            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test framework item","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","displayCategory":"second","ref":"test-requirement-1","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1794,7 +1794,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 685.65775ms
+        duration: 893.953541ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1806,7 +1806,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation UpdateComplianceFrameworkItem ($input: UpdateComplianceFrameworkItemInput!) {\n\tupdateComplianceFrameworkItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe","updates":{"name":"tf-provider-acc-test updated name","description":"","displayCategory":"","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","ref":"test-requirement-1","webLink":""}}},"operationName":"UpdateComplianceFrameworkItem"}'
+        body: '{"query":"\nmutation UpdateComplianceFrameworkItem ($input: UpdateComplianceFrameworkItemInput!) {\n\tupdateComplianceFrameworkItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162","updates":{"name":"tf-provider-acc-test updated name","description":"","displayCategory":"","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","ref":"test-requirement-1","webLink":""}}},"operationName":"UpdateComplianceFrameworkItem"}'
         form: {}
         headers:
             Cache-Control:
@@ -1824,7 +1824,7 @@ interactions:
         content_length: 89
         uncompressed: false
         body: |
-            {"data":{"updateComplianceFrameworkItem":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"}}}
+            {"data":{"updateComplianceFrameworkItem":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1872,7 +1872,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 721.730125ms
+        duration: 1.081869291s
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1884,7 +1884,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -1902,7 +1902,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1950,7 +1950,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 420.423875ms
+        duration: 1.130048875s
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1962,7 +1962,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -1980,7 +1980,7 @@ interactions:
         content_length: 346
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"742249c5-f37f-4363-b498-1a5258878cf5","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"a740f331-5775-4e21-9e72-094d08e874f1","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","name":"tf-provider-acc test FrameworkItem","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -2028,7 +2028,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 603.381667ms
+        duration: 760.301125ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -2040,7 +2040,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"},"operationName":"GetComplianceFrameworkItemById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkItemById ($id: ID!) {\n\tcomplianceFrameworkItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tframeworkId\n\t\tgroupId\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t}\n}\n","variables":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"},"operationName":"GetComplianceFrameworkItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -2058,7 +2058,7 @@ interactions:
         content_length: 264
         uncompressed: false
         body: |
-            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc-test updated name","description":"","frameworkId":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0","groupId":"742249c5-f37f-4363-b498-1a5258878cf5","displayCategory":"","ref":"test-requirement-1","webLink":null}}}
+            {"data":{"complianceFrameworkItem":{"name":"tf-provider-acc-test updated name","description":"","frameworkId":"fa03a945-249f-49f7-99bd-090391f313f1","groupId":"a740f331-5775-4e21-9e72-094d08e874f1","displayCategory":"","ref":"test-requirement-1","webLink":null}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -2106,7 +2106,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 848.785708ms
+        duration: 974.324459ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -2118,7 +2118,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation DeleteComplianceFrameworkItem ($id: ID!) {\n\tdeleteComplianceFrameworkItem(input: {id:$id})\n}\n","variables":{"id":"e663c32d-d90c-4f76-b0b8-67355bc826fe"},"operationName":"DeleteComplianceFrameworkItem"}'
+        body: '{"query":"\nmutation DeleteComplianceFrameworkItem ($id: ID!) {\n\tdeleteComplianceFrameworkItem(input: {id:$id})\n}\n","variables":{"id":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"},"operationName":"DeleteComplianceFrameworkItem"}'
         form: {}
         headers:
             Cache-Control:
@@ -2136,7 +2136,7 @@ interactions:
         content_length: 82
         uncompressed: false
         body: |
-            {"data":{"deleteComplianceFrameworkItem":"e663c32d-d90c-4f76-b0b8-67355bc826fe"}}
+            {"data":{"deleteComplianceFrameworkItem":"76de4d7b-aa79-4f10-83bb-6dc6c92cc162"}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -2184,7 +2184,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 380.3455ms
+        duration: 395.210708ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -2196,7 +2196,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation DeleteComplianceGroup ($id: ID!) {\n\tdeleteComplianceGroup(input: {id:$id})\n}\n","variables":{"id":"742249c5-f37f-4363-b498-1a5258878cf5"},"operationName":"DeleteComplianceGroup"}'
+        body: '{"query":"\nmutation DeleteComplianceGroup ($id: ID!) {\n\tdeleteComplianceGroup(input: {id:$id})\n}\n","variables":{"id":"a740f331-5775-4e21-9e72-094d08e874f1"},"operationName":"DeleteComplianceGroup"}'
         form: {}
         headers:
             Cache-Control:
@@ -2214,7 +2214,7 @@ interactions:
         content_length: 74
         uncompressed: false
         body: |
-            {"data":{"deleteComplianceGroup":"742249c5-f37f-4363-b498-1a5258878cf5"}}
+            {"data":{"deleteComplianceGroup":"a740f331-5775-4e21-9e72-094d08e874f1"}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -2262,7 +2262,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 343.578042ms
+        duration: 365.244625ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -2274,7 +2274,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation DeleteComplianceFramework ($input: DeleteComplianceFrameworkInput!) {\n\tdeleteComplianceFramework(input: $input)\n}\n","variables":{"input":{"id":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"}},"operationName":"DeleteComplianceFramework"}'
+        body: '{"query":"\nmutation DeleteComplianceFramework ($input: DeleteComplianceFrameworkInput!) {\n\tdeleteComplianceFramework(input: $input)\n}\n","variables":{"input":{"id":"fa03a945-249f-49f7-99bd-090391f313f1"}},"operationName":"DeleteComplianceFramework"}'
         form: {}
         headers:
             Cache-Control:
@@ -2292,7 +2292,7 @@ interactions:
         content_length: 78
         uncompressed: false
         body: |
-            {"data":{"deleteComplianceFramework":"2fa12121-6e6f-4348-9ed7-bde5e9b0eae0"}}
+            {"data":{"deleteComplianceFramework":"fa03a945-249f-49f7-99bd-090391f313f1"}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -2340,4 +2340,4 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 815.4875ms
+        duration: 858.514916ms

--- a/jupiterone/cassettes/TestFramework_Basic.yaml
+++ b/jupiterone/cassettes/TestFramework_Basic.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 431
+        content_length: 409
         transfer_encoding: []
         trailer: {}
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation CreateComplianceFramework ($framework: CreateComplianceFrameworkInput!) {\n\tcreateComplianceFramework(input: $framework) {\n\t\tid\n\t}\n}\n","variables":{"framework":{"name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[{"env":"prod"}]}},"operationName":"CreateComplianceFramework"}'
+        body: '{"query":"\nmutation CreateComplianceFramework ($framework: CreateComplianceFrameworkInput!) {\n\tcreateComplianceFramework(input: $framework) {\n\t\tid\n\t}\n}\n","variables":{"framework":{"name":"Updated Framework Name","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[]}},"operationName":"CreateComplianceFramework"}'
         form: {}
         headers:
             Cache-Control:
@@ -30,7 +30,7 @@ interactions:
         content_length: 85
         uncompressed: false
         body: |
-            {"data":{"createComplianceFramework":{"id":"d1694465-728b-4371-a11b-797222a193e1"}}}
+            {"data":{"createComplianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -78,7 +78,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.705535792s
+        duration: 1.675555542s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -90,241 +90,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"d1694465-728b-4371-a11b-797222a193e1"},"operationName":"GetComplianceFrameworkById"}'
-        form: {}
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Type:
-                - application/json
-        url: https://graphql.us.jupiterone.io/
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 394
-        uncompressed: false
-        body: |
-            {"data":{"complianceFramework":{"id":"d1694465-728b-4371-a11b-797222a193e1","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[{"env":"prod"}],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
-        headers:
-            Access-Control-Allow-Credentials:
-                - "true"
-            Content-Length:
-                - "394"
-            Content-Security-Policy:
-                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
-            Content-Type:
-                - application/json
-            Cross-Origin-Embedder-Policy:
-                - require-corp
-            Cross-Origin-Opener-Policy:
-                - same-origin
-            Cross-Origin-Resource-Policy:
-                - same-origin
-            Expect-Ct:
-                - max-age=0
-            Origin-Agent-Cluster:
-                - ?1
-            Ratelimit-Limit:
-                - "1000"
-            Ratelimit-Remaining:
-                - "999"
-            Ratelimit-Requested:
-                - "1"
-            Ratelimit-Reset:
-                - "1"
-            Referrer-Policy:
-                - no-referrer
-            Strict-Transport-Security:
-                - max-age=15552000; includeSubDomains
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Dns-Prefetch-Control:
-                - "off"
-            X-Download-Options:
-                - noopen
-            X-Frame-Options:
-                - SAMEORIGIN
-            X-Permitted-Cross-Domain-Policies:
-                - none
-            X-Xss-Protection:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 394.30625ms
-    - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 451
-        transfer_encoding: []
-        trailer: {}
-        host: graphql.us.jupiterone.io
-        remote_addr: ""
-        request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"d1694465-728b-4371-a11b-797222a193e1"},"operationName":"GetComplianceFrameworkById"}'
-        form: {}
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Type:
-                - application/json
-        url: https://graphql.us.jupiterone.io/
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 394
-        uncompressed: false
-        body: |
-            {"data":{"complianceFramework":{"id":"d1694465-728b-4371-a11b-797222a193e1","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[{"env":"prod"}],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
-        headers:
-            Access-Control-Allow-Credentials:
-                - "true"
-            Content-Length:
-                - "394"
-            Content-Security-Policy:
-                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
-            Content-Type:
-                - application/json
-            Cross-Origin-Embedder-Policy:
-                - require-corp
-            Cross-Origin-Opener-Policy:
-                - same-origin
-            Cross-Origin-Resource-Policy:
-                - same-origin
-            Expect-Ct:
-                - max-age=0
-            Origin-Agent-Cluster:
-                - ?1
-            Ratelimit-Limit:
-                - "1000"
-            Ratelimit-Remaining:
-                - "999"
-            Ratelimit-Requested:
-                - "1"
-            Ratelimit-Reset:
-                - "1"
-            Referrer-Policy:
-                - no-referrer
-            Strict-Transport-Security:
-                - max-age=15552000; includeSubDomains
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Dns-Prefetch-Control:
-                - "off"
-            X-Download-Options:
-                - noopen
-            X-Frame-Options:
-                - SAMEORIGIN
-            X-Permitted-Cross-Domain-Policies:
-                - none
-            X-Xss-Protection:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 358.692917ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 411
-        transfer_encoding: []
-        trailer: {}
-        host: graphql.us.jupiterone.io
-        remote_addr: ""
-        request_uri: ""
-        body: '{"query":"\nmutation UpdateComplianceFramework ($input: UpdateComplianceFrameworkInput!) {\n\tupdateComplianceFramework(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"d1694465-728b-4371-a11b-797222a193e1","updates":{"name":"Updated Framework Name","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[]}}},"operationName":"UpdateComplianceFramework"}'
-        form: {}
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Type:
-                - application/json
-        url: https://graphql.us.jupiterone.io/
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 85
-        uncompressed: false
-        body: |
-            {"data":{"updateComplianceFramework":{"id":"d1694465-728b-4371-a11b-797222a193e1"}}}
-        headers:
-            Access-Control-Allow-Credentials:
-                - "true"
-            Content-Length:
-                - "85"
-            Content-Security-Policy:
-                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
-            Content-Type:
-                - application/json
-            Cross-Origin-Embedder-Policy:
-                - require-corp
-            Cross-Origin-Opener-Policy:
-                - same-origin
-            Cross-Origin-Resource-Policy:
-                - same-origin
-            Expect-Ct:
-                - max-age=0
-            Origin-Agent-Cluster:
-                - ?1
-            Ratelimit-Limit:
-                - "1000"
-            Ratelimit-Remaining:
-                - "999"
-            Ratelimit-Requested:
-                - "1"
-            Ratelimit-Reset:
-                - "1"
-            Referrer-Policy:
-                - no-referrer
-            Strict-Transport-Security:
-                - max-age=15552000; includeSubDomains
-            Vary:
-                - Origin
-            X-Content-Type-Options:
-                - nosniff
-            X-Dns-Prefetch-Control:
-                - "off"
-            X-Download-Options:
-                - noopen
-            X-Frame-Options:
-                - SAMEORIGIN
-            X-Permitted-Cross-Domain-Policies:
-                - none
-            X-Xss-Protection:
-                - "0"
-        status: 200 OK
-        code: 200
-        duration: 887.970042ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 451
-        transfer_encoding: []
-        trailer: {}
-        host: graphql.us.jupiterone.io
-        remote_addr: ""
-        request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"d1694465-728b-4371-a11b-797222a193e1"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -342,7 +108,7 @@ interactions:
         content_length: 372
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"d1694465-728b-4371-a11b-797222a193e1","name":"Updated Framework Name","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"Updated Framework Name","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -390,8 +156,1178 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 469.612042ms
+        duration: 423.507125ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 451
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"Updated Framework Name","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "372"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 382.849917ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 419
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation UpdateComplianceFramework ($input: UpdateComplianceFrameworkInput!) {\n\tupdateComplianceFramework(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","updates":{"name":"tf-provider-acc-test-framework","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[]}}},"operationName":"UpdateComplianceFramework"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            {"data":{"updateComplianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "85"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 1.232787291s
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 451
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 380
+        uncompressed: false
+        body: |
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "380"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 816.872875ms
     - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 451
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 380
+        uncompressed: false
+        body: |
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "380"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 715.64275ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 433
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation UpdateComplianceFramework ($input: UpdateComplianceFrameworkInput!) {\n\tupdateComplianceFramework(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","updates":{"name":"tf-provider-acc-test-framework","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[{"env":"prod"}]}}},"operationName":"UpdateComplianceFramework"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            {"data":{"updateComplianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "85"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 1.786384708s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 451
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 394
+        uncompressed: false
+        body: |
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[{"env":"prod"}],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "394"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 404.899667ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 451
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 394
+        uncompressed: false
+        body: |
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[{"env":"prod"}],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "394"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 455.194542ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 411
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation UpdateComplianceFramework ($input: UpdateComplianceFrameworkInput!) {\n\tupdateComplianceFramework(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","updates":{"name":"Updated Framework Name","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[]}}},"operationName":"UpdateComplianceFramework"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            {"data":{"updateComplianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "85"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 905.940208ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 451
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"Updated Framework Name","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "372"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 382.859958ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 451
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"Updated Framework Name","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "372"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 491.457292ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 419
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation UpdateComplianceFramework ($input: UpdateComplianceFrameworkInput!) {\n\tupdateComplianceFramework(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","updates":{"name":"tf-provider-acc-test-framework","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[]}}},"operationName":"UpdateComplianceFramework"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            {"data":{"updateComplianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "85"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 1.049076458s
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 451
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 380
+        uncompressed: false
+        body: |
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "380"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 416.215834ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 451
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 380
+        uncompressed: false
+        body: |
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "380"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 391.981ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 411
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation UpdateComplianceFramework ($input: UpdateComplianceFrameworkInput!) {\n\tupdateComplianceFramework(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","updates":{"name":"Updated Framework Name","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[]}}},"operationName":"UpdateComplianceFramework"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 85
+        uncompressed: false
+        body: |
+            {"data":{"updateComplianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "85"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 1.4663795s
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 451
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"},"operationName":"GetComplianceFrameworkById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 372
+        uncompressed: false
+        body: |
+            {"data":{"complianceFramework":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19","name":"Updated Framework Name","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "372"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 389.349583ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -402,7 +1338,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation DeleteComplianceFramework ($input: DeleteComplianceFrameworkInput!) {\n\tdeleteComplianceFramework(input: $input)\n}\n","variables":{"input":{"id":"d1694465-728b-4371-a11b-797222a193e1"}},"operationName":"DeleteComplianceFramework"}'
+        body: '{"query":"\nmutation DeleteComplianceFramework ($input: DeleteComplianceFrameworkInput!) {\n\tdeleteComplianceFramework(input: $input)\n}\n","variables":{"input":{"id":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"}},"operationName":"DeleteComplianceFramework"}'
         form: {}
         headers:
             Cache-Control:
@@ -420,7 +1356,7 @@ interactions:
         content_length: 78
         uncompressed: false
         body: |
-            {"data":{"deleteComplianceFramework":"d1694465-728b-4371-a11b-797222a193e1"}}
+            {"data":{"deleteComplianceFramework":"84223bea-b64f-49d7-9ee7-74a4e35d0c19"}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -468,4 +1404,4 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 830.945916ms
+        duration: 1.183127792s

--- a/jupiterone/cassettes/TestGroup_Basic.yaml
+++ b/jupiterone/cassettes/TestGroup_Basic.yaml
@@ -30,7 +30,7 @@ interactions:
         content_length: 85
         uncompressed: false
         body: |
-            {"data":{"createComplianceFramework":{"id":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"}}}
+            {"data":{"createComplianceFramework":{"id":"bc28ea72-4da6-46bf-981b-e49f574391b0"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -78,7 +78,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 996.113209ms
+        duration: 811.555ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation CreateComplianceGroup ($input: CreateComplianceGroupInput!) {\n\tcreateComplianceGroup(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"name":"tf-provider-acc test Group","description":"","displayCategory":"","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","webLink":""}},"operationName":"CreateComplianceGroup"}'
+        body: '{"query":"\nmutation CreateComplianceGroup ($input: CreateComplianceGroupInput!) {\n\tcreateComplianceGroup(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"name":"tf-provider-acc test Group","description":"","displayCategory":"","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","webLink":""}},"operationName":"CreateComplianceGroup"}'
         form: {}
         headers:
             Cache-Control:
@@ -108,7 +108,7 @@ interactions:
         content_length: 81
         uncompressed: false
         body: |
-            {"data":{"createComplianceGroup":{"id":"b900023d-8739-45fe-b0a7-403224610a0f"}}}
+            {"data":{"createComplianceGroup":{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -156,7 +156,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 784.45925ms
+        duration: 628.132666ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -186,7 +186,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -234,7 +234,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 365.095459ms
+        duration: 444.997583ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -246,7 +246,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -264,7 +264,7 @@ interactions:
         content_length: 234
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"b900023d-8739-45fe-b0a7-403224610a0f","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc test Group","description":"","displayCategory":"","webLink":null}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc test Group","description":"","displayCategory":"","webLink":null}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -312,7 +312,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 950.697209ms
+        duration: 550.378291ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -324,7 +324,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -342,7 +342,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -390,7 +390,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 431.972541ms
+        duration: 414.357416ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -402,7 +402,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -420,7 +420,7 @@ interactions:
         content_length: 234
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"b900023d-8739-45fe-b0a7-403224610a0f","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc test Group","description":"","displayCategory":"","webLink":null}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc test Group","description":"","displayCategory":"","webLink":null}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -468,7 +468,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 818.827834ms
+        duration: 668.864583ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -480,7 +480,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation UpdateComplianceGroup ($input: UpdateComplianceGroupInput!) {\n\tupdateComplianceGroup(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"b900023d-8739-45fe-b0a7-403224610a0f","updates":{"name":"tf-provider-acc test Group","description":"tf-provider acceptance test group","displayCategory":"first","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceGroup"}'
+        body: '{"query":"\nmutation UpdateComplianceGroup ($input: UpdateComplianceGroupInput!) {\n\tupdateComplianceGroup(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf","updates":{"name":"tf-provider-acc test Group","description":"tf-provider acceptance test group","displayCategory":"first","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceGroup"}'
         form: {}
         headers:
             Cache-Control:
@@ -498,7 +498,7 @@ interactions:
         content_length: 81
         uncompressed: false
         body: |
-            {"data":{"updateComplianceGroup":{"id":"b900023d-8739-45fe-b0a7-403224610a0f"}}}
+            {"data":{"updateComplianceGroup":{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -546,7 +546,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 658.6075ms
+        duration: 656.276459ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -558,7 +558,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -576,7 +576,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -624,7 +624,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 476.190458ms
+        duration: 416.050375ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -636,7 +636,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -654,7 +654,7 @@ interactions:
         content_length: 338
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"b900023d-8739-45fe-b0a7-403224610a0f","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc test Group","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc test Group","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -702,7 +702,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 673.471708ms
+        duration: 670.181791ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -714,7 +714,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -732,7 +732,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -780,7 +780,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 445.126958ms
+        duration: 414.040291ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -810,7 +810,7 @@ interactions:
         content_length: 338
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"b900023d-8739-45fe-b0a7-403224610a0f","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc test Group","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc test Group","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -858,7 +858,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 649.756667ms
+        duration: 581.08375ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -870,7 +870,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation UpdateComplianceGroup ($input: UpdateComplianceGroupInput!) {\n\tupdateComplianceGroup(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"b900023d-8739-45fe-b0a7-403224610a0f","updates":{"name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test group","displayCategory":"first","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceGroup"}'
+        body: '{"query":"\nmutation UpdateComplianceGroup ($input: UpdateComplianceGroupInput!) {\n\tupdateComplianceGroup(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf","updates":{"name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test group","displayCategory":"first","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceGroup"}'
         form: {}
         headers:
             Cache-Control:
@@ -888,7 +888,7 @@ interactions:
         content_length: 81
         uncompressed: false
         body: |
-            {"data":{"updateComplianceGroup":{"id":"b900023d-8739-45fe-b0a7-403224610a0f"}}}
+            {"data":{"updateComplianceGroup":{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -936,7 +936,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 615.201541ms
+        duration: 599.962417ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -948,7 +948,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -966,7 +966,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1014,7 +1014,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 429.512916ms
+        duration: 357.090166ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -1026,7 +1026,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -1044,7 +1044,7 @@ interactions:
         content_length: 345
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"b900023d-8739-45fe-b0a7-403224610a0f","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1092,7 +1092,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 585.311583ms
+        duration: 617.055166ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -1104,7 +1104,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -1122,7 +1122,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1170,7 +1170,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 471.571416ms
+        duration: 393.512375ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -1182,7 +1182,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -1200,7 +1200,7 @@ interactions:
         content_length: 345
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"b900023d-8739-45fe-b0a7-403224610a0f","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test group","displayCategory":"first","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1248,7 +1248,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 635.174167ms
+        duration: 618.185917ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -1260,7 +1260,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation UpdateComplianceGroup ($input: UpdateComplianceGroupInput!) {\n\tupdateComplianceGroup(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"b900023d-8739-45fe-b0a7-403224610a0f","updates":{"name":"tf-provider-acc test Group","description":"","displayCategory":"","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","webLink":""}}},"operationName":"UpdateComplianceGroup"}'
+        body: '{"query":"\nmutation UpdateComplianceGroup ($input: UpdateComplianceGroupInput!) {\n\tupdateComplianceGroup(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf","updates":{"name":"tf-provider-acc test Group","description":"","displayCategory":"","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","webLink":""}}},"operationName":"UpdateComplianceGroup"}'
         form: {}
         headers:
             Cache-Control:
@@ -1278,7 +1278,7 @@ interactions:
         content_length: 81
         uncompressed: false
         body: |
-            {"data":{"updateComplianceGroup":{"id":"b900023d-8739-45fe-b0a7-403224610a0f"}}}
+            {"data":{"updateComplianceGroup":{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1326,7 +1326,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 749.440875ms
+        duration: 635.787875ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -1338,7 +1338,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceFrameworkById"}'
+        body: '{"query":"\nquery GetComplianceFrameworkById ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tid\n\t\tname\n\t\tversion\n\t\tframeworkType\n\t\twebLink\n\t\tscopeFilters\n\t\tsummaryConfig {\n\t\t\tshowPoliciesAndProcedures\n\t\t\tshowEvidence\n\t\t\tshowGapAnalysis\n\t\t\tshowAuditTracking\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceFrameworkById"}'
         form: {}
         headers:
             Cache-Control:
@@ -1356,7 +1356,7 @@ interactions:
         content_length: 380
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"id":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
+            {"data":{"complianceFramework":{"id":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc-test-framework","version":"v1","frameworkType":"STANDARD","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints","scopeFilters":[],"summaryConfig":{"showPoliciesAndProcedures":true,"showEvidence":true,"showGapAnalysis":true,"showAuditTracking":false}}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1404,7 +1404,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 477.288459ms
+        duration: 409.997292ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -1416,7 +1416,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"},"operationName":"GetComplianceGroups"}'
+        body: '{"query":"\nquery GetComplianceGroups ($frameworkId: ID!) {\n\tcomplianceFramework(input: {id:$frameworkId}) {\n\t\tgroups {\n\t\t\tid\n\t\t\tframeworkId\n\t\t\tname\n\t\t\tdescription\n\t\t\tdisplayCategory\n\t\t\twebLink\n\t\t}\n\t}\n}\n","variables":{"frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0"},"operationName":"GetComplianceGroups"}'
         form: {}
         headers:
             Cache-Control:
@@ -1434,7 +1434,7 @@ interactions:
         content_length: 234
         uncompressed: false
         body: |
-            {"data":{"complianceFramework":{"groups":[{"id":"b900023d-8739-45fe-b0a7-403224610a0f","frameworkId":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0","name":"tf-provider-acc test Group","description":"","displayCategory":"","webLink":null}]}}}
+            {"data":{"complianceFramework":{"groups":[{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf","frameworkId":"bc28ea72-4da6-46bf-981b-e49f574391b0","name":"tf-provider-acc test Group","description":"","displayCategory":"","webLink":null}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1482,7 +1482,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 688.919792ms
+        duration: 742.838792ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1494,7 +1494,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation DeleteComplianceGroup ($id: ID!) {\n\tdeleteComplianceGroup(input: {id:$id})\n}\n","variables":{"id":"b900023d-8739-45fe-b0a7-403224610a0f"},"operationName":"DeleteComplianceGroup"}'
+        body: '{"query":"\nmutation DeleteComplianceGroup ($id: ID!) {\n\tdeleteComplianceGroup(input: {id:$id})\n}\n","variables":{"id":"5d1e6712-30e0-4856-9b2e-075b207b0acf"},"operationName":"DeleteComplianceGroup"}'
         form: {}
         headers:
             Cache-Control:
@@ -1512,7 +1512,7 @@ interactions:
         content_length: 74
         uncompressed: false
         body: |
-            {"data":{"deleteComplianceGroup":"b900023d-8739-45fe-b0a7-403224610a0f"}}
+            {"data":{"deleteComplianceGroup":"5d1e6712-30e0-4856-9b2e-075b207b0acf"}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1560,7 +1560,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 356.548417ms
+        duration: 357.2235ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -1572,7 +1572,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation DeleteComplianceFramework ($input: DeleteComplianceFrameworkInput!) {\n\tdeleteComplianceFramework(input: $input)\n}\n","variables":{"input":{"id":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"}},"operationName":"DeleteComplianceFramework"}'
+        body: '{"query":"\nmutation DeleteComplianceFramework ($input: DeleteComplianceFrameworkInput!) {\n\tdeleteComplianceFramework(input: $input)\n}\n","variables":{"input":{"id":"bc28ea72-4da6-46bf-981b-e49f574391b0"}},"operationName":"DeleteComplianceFramework"}'
         form: {}
         headers:
             Cache-Control:
@@ -1590,7 +1590,7 @@ interactions:
         content_length: 78
         uncompressed: false
         body: |
-            {"data":{"deleteComplianceFramework":"67d99820-c5ef-4c78-8f1f-c2f9f189aec0"}}
+            {"data":{"deleteComplianceFramework":"bc28ea72-4da6-46bf-981b-e49f574391b0"}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -1638,4 +1638,4 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 883.708083ms
+        duration: 740.34975ms

--- a/jupiterone/cassettes/TestInlineRuleInstance_Basic.yaml
+++ b/jupiterone/cassettes/TestInlineRuleInstance_Basic.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1170
+        content_length: 1192
         transfer_encoding: []
         trailer: {}
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation CreateInlineQuestionRuleInstance ($instance: CreateInlineQuestionRuleInstanceInput!) {\n\tcreateQuestionRuleInstance: createInlineQuestionRuleInstance(instance: $instance) {\n\t\tid\n\t\tversion\n\t\tspecVersion\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t}\n}\n","variables":{"instance":{"question":{"queries":[{"query":"Find DataStore with classification=(''critical'' or ''sensitive'' or ''confidential'' or ''restricted'') and encrypted!=true","name":"query0","version":"v1","includeDeleted":false}]},"templates":null,"tags":["tf_acc:1","tf_acc:2"],"name":"tf-provider-test-rule","description":"Test","specVersion":1,"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"pollingInterval":"ONE_WEEK","notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":true}},"operationName":"CreateInlineQuestionRuleInstance"}'
+        body: '{"query":"\nmutation CreateInlineQuestionRuleInstance ($instance: CreateInlineQuestionRuleInstanceInput!) {\n\tcreateQuestionRuleInstance: createInlineQuestionRuleInstance(instance: $instance) {\n\t\tid\n\t\tversion\n\t\tspecVersion\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t}\n}\n","variables":{"instance":{"question":{"queries":[{"query":"Find DataStore with classification=(''critical'' or ''sensitive'' or ''confidential'' or ''restricted'') and encrypted!=true","name":"query0","version":"v1","includeDeleted":false}]},"templates":null,"tags":["tf_acc:1","tf_acc:2"],"name":"tf-provider-test-rule","description":"Test","specVersion":1,"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"pollingInterval":"ONE_WEEK","notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":true,"remediationSteps":""}},"operationName":"CreateInlineQuestionRuleInstance"}'
         form: {}
         headers:
             Cache-Control:
@@ -27,15 +27,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 624
+        content_length: 623
         uncompressed: false
         body: |
-            {"errors":[{"message":"Rule with name already exists in account (name=tf-provider-test-rule)","extensions":{"code":"BAD_USER_INPUT","serviceName":"rules","exception":{"stacktrace":["UserInputError: Rule with name already exists in account (name=tf-provider-test-rule)","    at createQuestionRuleInstance (/var/task/index.js:1433339:13)","    at runMicrotasks (<anonymous>)","    at processTicksAndRejections (internal/process/task_queues.js:95:5)"],"message":"Rule with name already exists in account (name=tf-provider-test-rule)","locations":[{"line":1,"column":103}],"path":["createQuestionRuleInstance"]}}}],"data":null}
+            {"data":{"createQuestionRuleInstance":{"id":"9e78ab2c-ac14-4345-a1a9-7d10875eb853","version":1,"specVersion":1,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false}]},"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"ab88a58a-7bdc-4f26-9016-24b89f963f86"},{"type":"CREATE_ALERT","id":"21ebc708-83fc-432c-b32e-3e75d33b2e48"}]}]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
             Content-Length:
-                - "624"
+                - "623"
             Content-Security-Policy:
                 - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
             Content-Type:
@@ -78,4 +78,394 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.577990667s
+        duration: 1.154465625s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 605
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionRuleInstance ($id: ID!) {\n\tquestionRuleInstance(id: $id) {\n\t\tid\n\t\tname\n\t\tdescription\n\t\tversion\n\t\tspecVersion\n\t\tlatest\n\t\tpollingInterval\n\t\tdeleted\n\t\ttype\n\t\ttemplates\n\t\tnotifyOnFailure\n\t\ttriggerActionsOnNewEntitiesOnly\n\t\tquestionId\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t\toutputs\n\t\ttags\n\t}\n}\n","variables":{"id":"9e78ab2c-ac14-4345-a1a9-7d10875eb853"},"operationName":"GetQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 923
+        uncompressed: false
+        body: |
+            {"data":{"questionRuleInstance":{"id":"9e78ab2c-ac14-4345-a1a9-7d10875eb853","name":"tf-provider-test-rule","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"type":"QUESTION","templates":null,"notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":true,"questionId":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"ab88a58a-7bdc-4f26-9016-24b89f963f86","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"21ebc708-83fc-432c-b32e-3e75d33b2e48"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tf_acc:1","tf_acc:2"]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "923"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 331.655583ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 605
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionRuleInstance ($id: ID!) {\n\tquestionRuleInstance(id: $id) {\n\t\tid\n\t\tname\n\t\tdescription\n\t\tversion\n\t\tspecVersion\n\t\tlatest\n\t\tpollingInterval\n\t\tdeleted\n\t\ttype\n\t\ttemplates\n\t\tnotifyOnFailure\n\t\ttriggerActionsOnNewEntitiesOnly\n\t\tquestionId\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t\toutputs\n\t\ttags\n\t}\n}\n","variables":{"id":"9e78ab2c-ac14-4345-a1a9-7d10875eb853"},"operationName":"GetQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 923
+        uncompressed: false
+        body: |
+            {"data":{"questionRuleInstance":{"id":"9e78ab2c-ac14-4345-a1a9-7d10875eb853","name":"tf-provider-test-rule","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"type":"QUESTION","templates":null,"notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":true,"questionId":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false}]},"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"ab88a58a-7bdc-4f26-9016-24b89f963f86","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"21ebc708-83fc-432c-b32e-3e75d33b2e48"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tf_acc:1","tf_acc:2"]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "923"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 316.632042ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1011
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation UpdateInlineQuestionRuleInstance ($instance: UpdateInlineQuestionRuleInstanceInput!) {\n\tupdateInlineQuestionRuleInstance(instance: $instance) {\n\t\tversion\n\t\tspecVersion\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t}\n}\n","variables":{"instance":{"question":{"queries":[{"query":"Find DataStore with classification=(''critical'' or ''sensitive'' or ''confidential'' or ''restricted'') and encrypted!=true","name":"query0","version":"v1","includeDeleted":false}]},"id":"9e78ab2c-ac14-4345-a1a9-7d10875eb853","version":1,"state":{"actions":null},"templates":null,"tags":["tf_acc:1","tf_acc:2"],"name":"tf-provider-test-rule","description":"Test","specVersion":1,"operations":[{"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"pollingInterval":"ONE_WEEK","notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":true}},"operationName":"UpdateInlineQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 304
+        uncompressed: false
+        body: |
+            {"data":{"updateInlineQuestionRuleInstance":{"version":2,"specVersion":1,"operations":[{"when":null,"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"d6a9ec76-c1d1-4b67-bc13-b7fa332eb306"},{"type":"CREATE_ALERT","id":"555049d8-f1b4-4bbd-8a41-c6d8adabb62b"}]}]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "304"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 566.361ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 605
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionRuleInstance ($id: ID!) {\n\tquestionRuleInstance(id: $id) {\n\t\tid\n\t\tname\n\t\tdescription\n\t\tversion\n\t\tspecVersion\n\t\tlatest\n\t\tpollingInterval\n\t\tdeleted\n\t\ttype\n\t\ttemplates\n\t\tnotifyOnFailure\n\t\ttriggerActionsOnNewEntitiesOnly\n\t\tquestionId\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t\toutputs\n\t\ttags\n\t}\n}\n","variables":{"id":"9e78ab2c-ac14-4345-a1a9-7d10875eb853"},"operationName":"GetQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 850
+        uncompressed: false
+        body: |
+            {"data":{"questionRuleInstance":{"id":"9e78ab2c-ac14-4345-a1a9-7d10875eb853","name":"tf-provider-test-rule","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"type":"QUESTION","templates":null,"notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":true,"questionId":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false}]},"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"d6a9ec76-c1d1-4b67-bc13-b7fa332eb306","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"555049d8-f1b4-4bbd-8a41-c6d8adabb62b"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tf_acc:1","tf_acc:2"]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "850"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 355.883458ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation DeleteRuleInstance ($id: ID!) {\n\tdeleteRuleInstance(id: $id) {\n\t\tid\n\t}\n}\n","variables":{"id":"9e78ab2c-ac14-4345-a1a9-7d10875eb853"},"operationName":"DeleteRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 78
+        uncompressed: false
+        body: |
+            {"data":{"deleteRuleInstance":{"id":"9e78ab2c-ac14-4345-a1a9-7d10875eb853"}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "78"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 436.307583ms

--- a/jupiterone/cassettes/TestInlineRuleInstance_BasicImport.yaml
+++ b/jupiterone/cassettes/TestInlineRuleInstance_BasicImport.yaml
@@ -6,13 +6,13 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 973
+        content_length: 995
         transfer_encoding: []
         trailer: {}
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation CreateInlineQuestionRuleInstance ($instance: CreateInlineQuestionRuleInstanceInput!) {\n\tcreateQuestionRuleInstance: createInlineQuestionRuleInstance(instance: $instance) {\n\t\tid\n\t\tversion\n\t\tspecVersion\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t}\n}\n","variables":{"instance":{"question":{"queries":[{"query":"Find DataStore with classification=(''critical'' or ''sensitive'' or ''confidential'' or ''restricted'') and encrypted!=true","name":"query0","version":"v1","includeDeleted":false}]},"templates":null,"tags":["tf_acc:1","tf_acc:2"],"name":"tf-provider-test-rule","description":"test","specVersion":1,"operations":[],"outputs":["queries.query0.total","alertLevel"],"pollingInterval":"ONE_DAY","notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":false}},"operationName":"CreateInlineQuestionRuleInstance"}'
+        body: '{"query":"\nmutation CreateInlineQuestionRuleInstance ($instance: CreateInlineQuestionRuleInstanceInput!) {\n\tcreateQuestionRuleInstance: createInlineQuestionRuleInstance(instance: $instance) {\n\t\tid\n\t\tversion\n\t\tspecVersion\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t}\n}\n","variables":{"instance":{"question":{"queries":[{"query":"Find DataStore with classification=(''critical'' or ''sensitive'' or ''confidential'' or ''restricted'') and encrypted!=true","name":"query0","version":"v1","includeDeleted":false}]},"templates":null,"tags":["tf_acc:1","tf_acc:2"],"name":"tf-provider-test-rule","description":"test","specVersion":1,"operations":[],"outputs":["queries.query0.total","alertLevel"],"pollingInterval":"ONE_DAY","notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":false,"remediationSteps":""}},"operationName":"CreateInlineQuestionRuleInstance"}'
         form: {}
         headers:
             Cache-Control:
@@ -30,7 +30,7 @@ interactions:
         content_length: 338
         uncompressed: false
         body: |
-            {"data":{"createQuestionRuleInstance":{"id":"b667115a-8a73-4681-b89c-9725a72c6c4c","version":1,"specVersion":1,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false}]},"operations":[]}}}
+            {"data":{"createQuestionRuleInstance":{"id":"df1ddec6-838f-4065-b6eb-2ecd51de58f1","version":1,"specVersion":1,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false}]},"operations":[]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -78,7 +78,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.094275209s
+        duration: 1.3022135s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetQuestionRuleInstance ($id: ID!) {\n\tquestionRuleInstance(id: $id) {\n\t\tid\n\t\tname\n\t\tdescription\n\t\tversion\n\t\tspecVersion\n\t\tlatest\n\t\tpollingInterval\n\t\tdeleted\n\t\ttype\n\t\ttemplates\n\t\tnotifyOnFailure\n\t\ttriggerActionsOnNewEntitiesOnly\n\t\tquestionId\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t\toutputs\n\t\ttags\n\t}\n}\n","variables":{"id":"b667115a-8a73-4681-b89c-9725a72c6c4c"},"operationName":"GetQuestionRuleInstance"}'
+        body: '{"query":"\nquery GetQuestionRuleInstance ($id: ID!) {\n\tquestionRuleInstance(id: $id) {\n\t\tid\n\t\tname\n\t\tdescription\n\t\tversion\n\t\tspecVersion\n\t\tlatest\n\t\tpollingInterval\n\t\tdeleted\n\t\ttype\n\t\ttemplates\n\t\tnotifyOnFailure\n\t\ttriggerActionsOnNewEntitiesOnly\n\t\tquestionId\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t\toutputs\n\t\ttags\n\t}\n}\n","variables":{"id":"df1ddec6-838f-4065-b6eb-2ecd51de58f1"},"operationName":"GetQuestionRuleInstance"}'
         form: {}
         headers:
             Cache-Control:
@@ -108,7 +108,7 @@ interactions:
         content_length: 638
         uncompressed: false
         body: |
-            {"data":{"questionRuleInstance":{"id":"b667115a-8a73-4681-b89c-9725a72c6c4c","name":"tf-provider-test-rule","description":"test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_DAY","deleted":false,"type":"QUESTION","templates":null,"notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":false,"questionId":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false}]},"operations":[],"outputs":["queries.query0.total","alertLevel"],"tags":["tf_acc:1","tf_acc:2"]}}}
+            {"data":{"questionRuleInstance":{"id":"df1ddec6-838f-4065-b6eb-2ecd51de58f1","name":"tf-provider-test-rule","description":"test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_DAY","deleted":false,"type":"QUESTION","templates":null,"notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":false,"questionId":null,"question":{"queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false}]},"operations":[],"outputs":["queries.query0.total","alertLevel"],"tags":["tf_acc:1","tf_acc:2"]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -156,7 +156,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 322.176458ms
+        duration: 318.138292ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation DeleteRuleInstance ($id: ID!) {\n\tdeleteRuleInstance(id: $id) {\n\t\tid\n\t}\n}\n","variables":{"id":"b667115a-8a73-4681-b89c-9725a72c6c4c"},"operationName":"DeleteRuleInstance"}'
+        body: '{"query":"\nmutation DeleteRuleInstance ($id: ID!) {\n\tdeleteRuleInstance(id: $id) {\n\t\tid\n\t}\n}\n","variables":{"id":"df1ddec6-838f-4065-b6eb-2ecd51de58f1"},"operationName":"DeleteRuleInstance"}'
         form: {}
         headers:
             Cache-Control:
@@ -186,7 +186,7 @@ interactions:
         content_length: 78
         uncompressed: false
         body: |
-            {"data":{"deleteRuleInstance":{"id":"b667115a-8a73-4681-b89c-9725a72c6c4c"}}}
+            {"data":{"deleteRuleInstance":{"id":"df1ddec6-838f-4065-b6eb-2ecd51de58f1"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -234,4 +234,4 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 354.22ms
+        duration: 321.64175ms

--- a/jupiterone/cassettes/TestLibraryItem_Basic.yaml
+++ b/jupiterone/cassettes/TestLibraryItem_Basic.yaml
@@ -30,7 +30,7 @@ interactions:
         content_length: 87
         uncompressed: false
         body: |
-            {"data":{"createComplianceLibraryItem":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"}}}
+            {"data":{"createComplianceLibraryItem":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -78,7 +78,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 1.048421958s
+        duration: 814.004291ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"},"operationName":"GetComplianceLibraryItemById"}'
+        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"},"operationName":"GetComplianceLibraryItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -156,7 +156,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 823.158958ms
+        duration: 732.782ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"},"operationName":"GetComplianceLibraryItemById"}'
+        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"},"operationName":"GetComplianceLibraryItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -234,7 +234,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 692.921375ms
+        duration: 523.44ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -246,7 +246,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation UpdateComplianceLibraryItem ($input: UpdateComplianceLibraryItemInput!) {\n\tupdateComplianceLibraryItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a","updates":{"name":"tf-provider-acc test LibraryItem","description":"tf-provider acceptance test library item","displayCategory":"third","ref":"test-requirement-2","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceLibraryItem"}'
+        body: '{"query":"\nmutation UpdateComplianceLibraryItem ($input: UpdateComplianceLibraryItemInput!) {\n\tupdateComplianceLibraryItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7","updates":{"name":"tf-provider-acc test LibraryItem","description":"tf-provider acceptance test library item","displayCategory":"third","ref":"test-requirement-2","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceLibraryItem"}'
         form: {}
         headers:
             Cache-Control:
@@ -264,7 +264,7 @@ interactions:
         content_length: 87
         uncompressed: false
         body: |
-            {"data":{"updateComplianceLibraryItem":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"}}}
+            {"data":{"updateComplianceLibraryItem":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -312,7 +312,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 807.280125ms
+        duration: 926.156208ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -324,7 +324,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"},"operationName":"GetComplianceLibraryItemById"}'
+        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"},"operationName":"GetComplianceLibraryItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -390,7 +390,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 564.576417ms
+        duration: 639.802791ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -402,7 +402,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"},"operationName":"GetComplianceLibraryItemById"}'
+        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"},"operationName":"GetComplianceLibraryItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -468,7 +468,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 580.363625ms
+        duration: 604.99475ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -480,7 +480,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation UpdateComplianceLibraryItem ($input: UpdateComplianceLibraryItemInput!) {\n\tupdateComplianceLibraryItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a","updates":{"name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test library item","displayCategory":"third","ref":"test-requirement-2","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceLibraryItem"}'
+        body: '{"query":"\nmutation UpdateComplianceLibraryItem ($input: UpdateComplianceLibraryItemInput!) {\n\tupdateComplianceLibraryItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7","updates":{"name":"tf-provider-acc-test updated name","description":"tf-provider acceptance test library item","displayCategory":"third","ref":"test-requirement-2","webLink":"https://community.askj1.com/kb/articles/795-compliance-api-endpoints"}}},"operationName":"UpdateComplianceLibraryItem"}'
         form: {}
         headers:
             Cache-Control:
@@ -498,7 +498,7 @@ interactions:
         content_length: 87
         uncompressed: false
         body: |
-            {"data":{"updateComplianceLibraryItem":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"}}}
+            {"data":{"updateComplianceLibraryItem":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -546,7 +546,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 792.8955ms
+        duration: 603.709875ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -558,7 +558,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"},"operationName":"GetComplianceLibraryItemById"}'
+        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"},"operationName":"GetComplianceLibraryItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -624,7 +624,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 624.816042ms
+        duration: 532.333833ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -636,7 +636,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"},"operationName":"GetComplianceLibraryItemById"}'
+        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"},"operationName":"GetComplianceLibraryItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -702,7 +702,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 667.865166ms
+        duration: 932.803083ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -714,7 +714,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation UpdateComplianceLibraryItem ($input: UpdateComplianceLibraryItemInput!) {\n\tupdateComplianceLibraryItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a","updates":{"name":"tf-provider-acc-test updated name","description":"","displayCategory":"","ref":"test-requirement-1","webLink":""}}},"operationName":"UpdateComplianceLibraryItem"}'
+        body: '{"query":"\nmutation UpdateComplianceLibraryItem ($input: UpdateComplianceLibraryItemInput!) {\n\tupdateComplianceLibraryItem(input: $input) {\n\t\tid\n\t}\n}\n","variables":{"input":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7","updates":{"name":"tf-provider-acc-test updated name","description":"","displayCategory":"","ref":"test-requirement-1","webLink":""}}},"operationName":"UpdateComplianceLibraryItem"}'
         form: {}
         headers:
             Cache-Control:
@@ -732,7 +732,7 @@ interactions:
         content_length: 87
         uncompressed: false
         body: |
-            {"data":{"updateComplianceLibraryItem":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"}}}
+            {"data":{"updateComplianceLibraryItem":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -780,7 +780,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 635.434042ms
+        duration: 628.269667ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -792,7 +792,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"},"operationName":"GetComplianceLibraryItemById"}'
+        body: '{"query":"\nquery GetComplianceLibraryItemById ($id: ID!) {\n\tcomplianceLibraryItem(input: {id:$id}) {\n\t\tname\n\t\tdescription\n\t\tdisplayCategory\n\t\tref\n\t\twebLink\n\t\tpolicyItemId\n\t}\n}\n","variables":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"},"operationName":"GetComplianceLibraryItemById"}'
         form: {}
         headers:
             Cache-Control:
@@ -858,7 +858,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 592.793625ms
+        duration: 587.510917ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -870,7 +870,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation DeleteComplianceLibraryItem ($id: ID!) {\n\tdeleteComplianceLibraryItem(input: {id:$id})\n}\n","variables":{"id":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"},"operationName":"DeleteComplianceLibraryItem"}'
+        body: '{"query":"\nmutation DeleteComplianceLibraryItem ($id: ID!) {\n\tdeleteComplianceLibraryItem(input: {id:$id})\n}\n","variables":{"id":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"},"operationName":"DeleteComplianceLibraryItem"}'
         form: {}
         headers:
             Cache-Control:
@@ -888,7 +888,7 @@ interactions:
         content_length: 80
         uncompressed: false
         body: |
-            {"data":{"deleteComplianceLibraryItem":"c3fcceb3-0432-410f-9ee2-f6fcda06960a"}}
+            {"data":{"deleteComplianceLibraryItem":"8b1cba81-a151-4f48-8c99-0df4ef026ad7"}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -936,4 +936,4 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 370.7255ms
+        duration: 404.92625ms

--- a/jupiterone/cassettes/TestQuestion_Basic.yaml
+++ b/jupiterone/cassettes/TestQuestion_Basic.yaml
@@ -30,7 +30,7 @@ interactions:
         content_length: 74
         uncompressed: false
         body: |
-            {"data":{"createQuestion":{"id":"04f52406-2511-483d-810b-c4a643ba77b0"}}}
+            {"data":{"createQuestion":{"id":"703b9538-1f54-4708-b025-624da5fa7491"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -78,7 +78,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 740.810917ms
+        duration: 749.9925ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"04f52406-2511-483d-810b-c4a643ba77b0"},"operationName":"GetQuestionById"}'
+        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"703b9538-1f54-4708-b025-624da5fa7491"},"operationName":"GetQuestionById"}'
         form: {}
         headers:
             Cache-Control:
@@ -108,7 +108,7 @@ interactions:
         content_length: 411
         uncompressed: false
         body: |
-            {"data":{"question":{"id":"04f52406-2511-483d-810b-c4a643ba77b0","title":"tf-provider-test-question","description":"Test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"INFORMATIVE"}],"tags":["tf_acc:1"],"compliance":[]}}}
+            {"data":{"question":{"id":"703b9538-1f54-4708-b025-624da5fa7491","title":"tf-provider-test-question","description":"Test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"INFORMATIVE"}],"tags":["tf_acc:1"],"compliance":[]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -156,7 +156,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 356.495458ms
+        duration: 381.497125ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -168,7 +168,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"04f52406-2511-483d-810b-c4a643ba77b0"},"operationName":"GetQuestionById"}'
+        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"703b9538-1f54-4708-b025-624da5fa7491"},"operationName":"GetQuestionById"}'
         form: {}
         headers:
             Cache-Control:
@@ -186,7 +186,7 @@ interactions:
         content_length: 411
         uncompressed: false
         body: |
-            {"data":{"question":{"id":"04f52406-2511-483d-810b-c4a643ba77b0","title":"tf-provider-test-question","description":"Test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"INFORMATIVE"}],"tags":["tf_acc:1"],"compliance":[]}}}
+            {"data":{"question":{"id":"703b9538-1f54-4708-b025-624da5fa7491","title":"tf-provider-test-question","description":"Test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"INFORMATIVE"}],"tags":["tf_acc:1"],"compliance":[]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -234,7 +234,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 350.674417ms
+        duration: 390.122959ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -246,7 +246,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation UpdateQuestion ($id: ID!, $update: QuestionUpdate!) {\n\tupdateQuestion(id: $id, update: $update) {\n\t\tid\n\t}\n}\n","variables":{"id":"04f52406-2511-483d-810b-c4a643ba77b0","update":{"title":"tf-provider-test-question","queries":[{"query":"Find DataStore with classification=(''critical'' or ''sensitive'' or ''confidential'' or ''restricted'') and encrypted!=true","version":"v1","name":"query0","resultsAre":"INFORMATIVE","includeDeleted":false}],"compliance":[],"tags":["tf_acc:2"],"description":"Test","showTrend":false,"pollingInterval":"ONE_DAY","widgetId":""}},"operationName":"UpdateQuestion"}'
+        body: '{"query":"\nmutation UpdateQuestion ($id: ID!, $update: QuestionUpdate!) {\n\tupdateQuestion(id: $id, update: $update) {\n\t\tid\n\t}\n}\n","variables":{"id":"703b9538-1f54-4708-b025-624da5fa7491","update":{"title":"tf-provider-test-question","queries":[{"query":"Find DataStore with classification=(''critical'' or ''sensitive'' or ''confidential'' or ''restricted'') and encrypted!=true","version":"v1","name":"query0","resultsAre":"INFORMATIVE","includeDeleted":false}],"compliance":[],"tags":["tf_acc:2"],"description":"Test","showTrend":false,"pollingInterval":"ONE_DAY","widgetId":""}},"operationName":"UpdateQuestion"}'
         form: {}
         headers:
             Cache-Control:
@@ -264,7 +264,7 @@ interactions:
         content_length: 74
         uncompressed: false
         body: |
-            {"data":{"updateQuestion":{"id":"04f52406-2511-483d-810b-c4a643ba77b0"}}}
+            {"data":{"updateQuestion":{"id":"703b9538-1f54-4708-b025-624da5fa7491"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -312,7 +312,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 444.306667ms
+        duration: 525.077125ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -324,7 +324,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"04f52406-2511-483d-810b-c4a643ba77b0"},"operationName":"GetQuestionById"}'
+        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"703b9538-1f54-4708-b025-624da5fa7491"},"operationName":"GetQuestionById"}'
         form: {}
         headers:
             Cache-Control:
@@ -342,7 +342,7 @@ interactions:
         content_length: 411
         uncompressed: false
         body: |
-            {"data":{"question":{"id":"04f52406-2511-483d-810b-c4a643ba77b0","title":"tf-provider-test-question","description":"Test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"INFORMATIVE"}],"tags":["tf_acc:2"],"compliance":[]}}}
+            {"data":{"question":{"id":"703b9538-1f54-4708-b025-624da5fa7491","title":"tf-provider-test-question","description":"Test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"INFORMATIVE"}],"tags":["tf_acc:2"],"compliance":[]}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -390,7 +390,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 326.15125ms
+        duration: 368.49425ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -402,7 +402,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nmutation DeleteQuestion ($id: ID!) {\n\tdeleteQuestion(id: $id) {\n\t\tid\n\t}\n}\n","variables":{"id":"04f52406-2511-483d-810b-c4a643ba77b0"},"operationName":"DeleteQuestion"}'
+        body: '{"query":"\nmutation DeleteQuestion ($id: ID!) {\n\tdeleteQuestion(id: $id) {\n\t\tid\n\t}\n}\n","variables":{"id":"703b9538-1f54-4708-b025-624da5fa7491"},"operationName":"DeleteQuestion"}'
         form: {}
         headers:
             Cache-Control:
@@ -420,7 +420,7 @@ interactions:
         content_length: 74
         uncompressed: false
         body: |
-            {"data":{"deleteQuestion":{"id":"04f52406-2511-483d-810b-c4a643ba77b0"}}}
+            {"data":{"deleteQuestion":{"id":"703b9538-1f54-4708-b025-624da5fa7491"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -468,4 +468,4 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 532.54575ms
+        duration: 420.311708ms

--- a/jupiterone/cassettes/TestQuestion_BasicImport.yaml
+++ b/jupiterone/cassettes/TestQuestion_BasicImport.yaml
@@ -30,7 +30,7 @@ interactions:
         content_length: 74
         uncompressed: false
         body: |
-            {"data":{"createQuestion":{"id":"7a32c4a2-8055-4dc2-9e72-206fc4aacde2"}}}
+            {"data":{"createQuestion":{"id":"15212bc2-c193-4447-bbd5-38a01e3389e9"}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -78,7 +78,7 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 688.467916ms
+        duration: 798.802208ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
         host: graphql.us.jupiterone.io
         remote_addr: ""
         request_uri: ""
-        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"7a32c4a2-8055-4dc2-9e72-206fc4aacde2"},"operationName":"GetQuestionById"}'
+        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"15212bc2-c193-4447-bbd5-38a01e3389e9"},"operationName":"GetQuestionById"}'
         form: {}
         headers:
             Cache-Control:
@@ -108,7 +108,7 @@ interactions:
         content_length: 405
         uncompressed: false
         body: |
-            {"data":{"question":{"id":"7a32c4a2-8055-4dc2-9e72-206fc4aacde2","title":"tf-provider-test-question","description":"test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"BAD"}],"tags":["tf_acc:1"],"compliance":null}}}
+            {"data":{"question":{"id":"15212bc2-c193-4447-bbd5-38a01e3389e9","title":"tf-provider-test-question","description":"test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"BAD"}],"tags":["tf_acc:1"],"compliance":null}}}
         headers:
             Access-Control-Allow-Credentials:
                 - "true"
@@ -156,4 +156,4 @@ interactions:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 330.614125ms
+        duration: 341.47775ms

--- a/jupiterone/cassettes/TestReferencedQuestionRule_Basic.yaml
+++ b/jupiterone/cassettes/TestReferencedQuestionRule_Basic.yaml
@@ -27,16 +27,835 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 132
+        content_length: 74
         uncompressed: false
-        body: "<html>\r\n<head><title>504 Gateway Time-out</title></head>\r\n<body>\r\n<center><h1>504 Gateway Time-out</h1></center>\r\n</body>\r\n</html>\r\n"
+        body: |
+            {"data":{"createQuestion":{"id":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9"}}}
         headers:
+            Access-Control-Allow-Credentials:
+                - "true"
             Content-Length:
-                - "132"
+                - "74"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
             Content-Type:
-                - text/html
-            Server:
-                - awselb/2.0
-        status: 504 Gateway Timeout
-        code: 504
-        duration: 1m0.278669834s
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 1.103059583s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 934
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation CreateReferencedQuestionRuleInstance ($instance: CreateReferencedQuestionRuleInstanceInput!) {\n\tcreateQuestionRuleInstance: createReferencedQuestionRuleInstance(instance: $instance) {\n\t\tid\n\t\tversion\n\t\tspecVersion\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t}\n}\n","variables":{"instance":{"questionId":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9","templates":null,"tags":["tf_acc:1","tf_acc:2"],"name":"tf-provider-test-rule","description":"Test","specVersion":1,"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"pollingInterval":"ONE_WEEK","notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":false,"remediationSteps":""}},"operationName":"CreateReferencedQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 415
+        uncompressed: false
+        body: |
+            {"data":{"createQuestionRuleInstance":{"id":"1397b823-a6b0-487f-805e-bc2d20de9cf8","version":1,"specVersion":1,"operations":[{"when":{"condition":"{{queries.query0.total != 0}}","specVersion":1,"type":"FILTER"},"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"ac2334ac-eb35-4704-84b2-68ab535e1b01"},{"type":"CREATE_ALERT","id":"ff831c5b-601e-4266-b6d9-5cb4f9caa2bc"}]}]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "415"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 1.398354959s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 419
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9"},"operationName":"GetQuestionById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 418
+        uncompressed: false
+        body: |
+            {"data":{"question":{"id":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9","title":"tf-provider-test-rule","description":"Test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"INFORMATIVE"}],"tags":["tf_acc:1","tf_acc:2"],"compliance":[]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "418"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 393.670209ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 605
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionRuleInstance ($id: ID!) {\n\tquestionRuleInstance(id: $id) {\n\t\tid\n\t\tname\n\t\tdescription\n\t\tversion\n\t\tspecVersion\n\t\tlatest\n\t\tpollingInterval\n\t\tdeleted\n\t\ttype\n\t\ttemplates\n\t\tnotifyOnFailure\n\t\ttriggerActionsOnNewEntitiesOnly\n\t\tquestionId\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t\toutputs\n\t\ttags\n\t}\n}\n","variables":{"id":"1397b823-a6b0-487f-805e-bc2d20de9cf8"},"operationName":"GetQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 766
+        uncompressed: false
+        body: |
+            {"data":{"questionRuleInstance":{"id":"1397b823-a6b0-487f-805e-bc2d20de9cf8","name":"tf-provider-test-rule","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"type":"QUESTION","templates":null,"notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":false,"questionId":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9","question":null,"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"ac2334ac-eb35-4704-84b2-68ab535e1b01","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"ff831c5b-601e-4266-b6d9-5cb4f9caa2bc"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tf_acc:1","tf_acc:2"]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "766"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 350.296375ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 419
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9"},"operationName":"GetQuestionById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 418
+        uncompressed: false
+        body: |
+            {"data":{"question":{"id":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9","title":"tf-provider-test-rule","description":"Test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"INFORMATIVE"}],"tags":["tf_acc:1","tf_acc:2"],"compliance":[]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "418"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 444.921833ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 605
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionRuleInstance ($id: ID!) {\n\tquestionRuleInstance(id: $id) {\n\t\tid\n\t\tname\n\t\tdescription\n\t\tversion\n\t\tspecVersion\n\t\tlatest\n\t\tpollingInterval\n\t\tdeleted\n\t\ttype\n\t\ttemplates\n\t\tnotifyOnFailure\n\t\ttriggerActionsOnNewEntitiesOnly\n\t\tquestionId\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t\toutputs\n\t\ttags\n\t}\n}\n","variables":{"id":"1397b823-a6b0-487f-805e-bc2d20de9cf8"},"operationName":"GetQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 766
+        uncompressed: false
+        body: |
+            {"data":{"questionRuleInstance":{"id":"1397b823-a6b0-487f-805e-bc2d20de9cf8","name":"tf-provider-test-rule","description":"Test","version":1,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"type":"QUESTION","templates":null,"notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":false,"questionId":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9","question":null,"operations":[{"when":{"type":"FILTER","condition":"{{queries.query0.total != 0}}","specVersion":1},"actions":[{"targetValue":"HIGH","id":"ac2334ac-eb35-4704-84b2-68ab535e1b01","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"ff831c5b-601e-4266-b6d9-5cb4f9caa2bc"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tf_acc:1","tf_acc:2"]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "766"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 337.51025ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 894
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation UpdateReferencedQuestionRuleInstance ($instance: UpdateReferencedQuestionRuleInstanceInput!) {\n\tupdateReferencedQuestionRuleInstance(instance: $instance) {\n\t\tversion\n\t\tspecVersion\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t}\n}\n","variables":{"instance":{"questionId":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9","id":"1397b823-a6b0-487f-805e-bc2d20de9cf8","version":1,"state":{"actions":null},"templates":null,"tags":["tf_acc:1","tf_acc:2"],"name":"tf-provider-test-rule","description":"Test","specVersion":1,"operations":[{"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY"},{"type":"CREATE_ALERT"}]}],"outputs":["queries.query0.total","alertLevel"],"pollingInterval":"ONE_WEEK","notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":false,"remediationSteps":""}},"operationName":"UpdateReferencedQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 308
+        uncompressed: false
+        body: |
+            {"data":{"updateReferencedQuestionRuleInstance":{"version":2,"specVersion":1,"operations":[{"when":null,"actions":[{"targetProperty":"alertLevel","targetValue":"HIGH","type":"SET_PROPERTY","id":"f99e6248-85e4-42ec-ba3e-42f331ca5481"},{"type":"CREATE_ALERT","id":"177ffb0b-ca57-408a-9b87-5f89dffcbff9"}]}]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "308"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 653.461958ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 419
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionById ($id: ID!) {\n\tquestion(id: $id) {\n\t\tid\n\t\ttitle\n\t\tdescription\n\t\tpollingInterval\n\t\tqueries {\n\t\t\tname\n\t\t\tquery\n\t\t\tversion\n\t\t\tincludeDeleted\n\t\t\tresultsAre\n\t\t}\n\t\ttags\n\t\tcompliance {\n\t\t\tstandard\n\t\t\trequirements\n\t\t\tcontrols\n\t\t}\n\t}\n}\n","variables":{"id":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9"},"operationName":"GetQuestionById"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 418
+        uncompressed: false
+        body: |
+            {"data":{"question":{"id":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9","title":"tf-provider-test-rule","description":"Test","pollingInterval":"ONE_DAY","queries":[{"name":"query0","query":"Find DataStore with classification=('critical' or 'sensitive' or 'confidential' or 'restricted') and encrypted!=true","version":"v1","includeDeleted":false,"resultsAre":"INFORMATIVE"}],"tags":["tf_acc:1","tf_acc:2"],"compliance":[]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "418"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 366.425292ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 605
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nquery GetQuestionRuleInstance ($id: ID!) {\n\tquestionRuleInstance(id: $id) {\n\t\tid\n\t\tname\n\t\tdescription\n\t\tversion\n\t\tspecVersion\n\t\tlatest\n\t\tpollingInterval\n\t\tdeleted\n\t\ttype\n\t\ttemplates\n\t\tnotifyOnFailure\n\t\ttriggerActionsOnNewEntitiesOnly\n\t\tquestionId\n\t\tquestion {\n\t\t\tqueries {\n\t\t\t\tname\n\t\t\t\tquery\n\t\t\t\tversion\n\t\t\t\tincludeDeleted\n\t\t\t}\n\t\t}\n\t\toperations {\n\t\t\twhen\n\t\t\tactions\n\t\t}\n\t\toutputs\n\t\ttags\n\t}\n}\n","variables":{"id":"1397b823-a6b0-487f-805e-bc2d20de9cf8"},"operationName":"GetQuestionRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 693
+        uncompressed: false
+        body: |
+            {"data":{"questionRuleInstance":{"id":"1397b823-a6b0-487f-805e-bc2d20de9cf8","name":"tf-provider-test-rule","description":"Test","version":2,"specVersion":1,"latest":true,"pollingInterval":"ONE_WEEK","deleted":false,"type":"QUESTION","templates":null,"notifyOnFailure":false,"triggerActionsOnNewEntitiesOnly":false,"questionId":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9","question":null,"operations":[{"when":null,"actions":[{"targetValue":"HIGH","id":"f99e6248-85e4-42ec-ba3e-42f331ca5481","type":"SET_PROPERTY","targetProperty":"alertLevel"},{"type":"CREATE_ALERT","id":"177ffb0b-ca57-408a-9b87-5f89dffcbff9"}]}],"outputs":["queries.query0.total","alertLevel"],"tags":["tf_acc:1","tf_acc:2"]}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "693"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 364.13425ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 200
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation DeleteRuleInstance ($id: ID!) {\n\tdeleteRuleInstance(id: $id) {\n\t\tid\n\t}\n}\n","variables":{"id":"1397b823-a6b0-487f-805e-bc2d20de9cf8"},"operationName":"DeleteRuleInstance"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 78
+        uncompressed: false
+        body: |
+            {"data":{"deleteRuleInstance":{"id":"1397b823-a6b0-487f-805e-bc2d20de9cf8"}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "78"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 353.208208ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 188
+        transfer_encoding: []
+        trailer: {}
+        host: graphql.us.jupiterone.io
+        remote_addr: ""
+        request_uri: ""
+        body: '{"query":"\nmutation DeleteQuestion ($id: ID!) {\n\tdeleteQuestion(id: $id) {\n\t\tid\n\t}\n}\n","variables":{"id":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9"},"operationName":"DeleteQuestion"}'
+        form: {}
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Type:
+                - application/json
+        url: https://graphql.us.jupiterone.io/
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 74
+        uncompressed: false
+        body: |
+            {"data":{"deleteQuestion":{"id":"8fbf10fd-5a37-4c29-b04d-5cea615a7fd9"}}}
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Content-Length:
+                - "74"
+            Content-Security-Policy:
+                - 'default-src ''self'';base-uri ''self'';block-all-mixed-content;font-src ''self'' https: data:;form-action ''self'';frame-ancestors ''self'';img-src ''self'' data:;object-src ''none'';script-src ''self'';script-src-attr ''none'';style-src ''self'' https: ''unsafe-inline'';upgrade-insecure-requests'
+            Content-Type:
+                - application/json
+            Cross-Origin-Embedder-Policy:
+                - require-corp
+            Cross-Origin-Opener-Policy:
+                - same-origin
+            Cross-Origin-Resource-Policy:
+                - same-origin
+            Expect-Ct:
+                - max-age=0
+            Origin-Agent-Cluster:
+                - ?1
+            Ratelimit-Limit:
+                - "1000"
+            Ratelimit-Remaining:
+                - "999"
+            Ratelimit-Requested:
+                - "1"
+            Ratelimit-Reset:
+                - "1"
+            Referrer-Policy:
+                - no-referrer
+            Strict-Transport-Security:
+                - max-age=15552000; includeSubDomains
+            Vary:
+                - Origin
+            X-Content-Type-Options:
+                - nosniff
+            X-Dns-Prefetch-Control:
+                - "off"
+            X-Download-Options:
+                - noopen
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Permitted-Cross-Domain-Policies:
+                - none
+            X-Xss-Protection:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 530.450708ms

--- a/jupiterone/internal/client/generated.go
+++ b/jupiterone/internal/client/generated.go
@@ -329,6 +329,7 @@ type CreateInlineQuestionRuleInstanceInput struct {
 	PollingInterval                 SchedulerPollingInterval `json:"pollingInterval"`
 	NotifyOnFailure                 bool                     `json:"notifyOnFailure"`
 	TriggerActionsOnNewEntitiesOnly bool                     `json:"triggerActionsOnNewEntitiesOnly"`
+	RemediationSteps                string                   `json:"remediationSteps"`
 }
 
 // GetQuestion returns CreateInlineQuestionRuleInstanceInput.Question, and is useful for accessing the field via an interface.
@@ -372,6 +373,11 @@ func (v *CreateInlineQuestionRuleInstanceInput) GetNotifyOnFailure() bool { retu
 // GetTriggerActionsOnNewEntitiesOnly returns CreateInlineQuestionRuleInstanceInput.TriggerActionsOnNewEntitiesOnly, and is useful for accessing the field via an interface.
 func (v *CreateInlineQuestionRuleInstanceInput) GetTriggerActionsOnNewEntitiesOnly() bool {
 	return v.TriggerActionsOnNewEntitiesOnly
+}
+
+// GetRemediationSteps returns CreateInlineQuestionRuleInstanceInput.RemediationSteps, and is useful for accessing the field via an interface.
+func (v *CreateInlineQuestionRuleInstanceInput) GetRemediationSteps() string {
+	return v.RemediationSteps
 }
 
 // CreateInlineQuestionRuleInstanceResponse is returned by CreateInlineQuestionRuleInstance on success.
@@ -485,6 +491,7 @@ type CreateReferencedQuestionRuleInstanceInput struct {
 	PollingInterval                 SchedulerPollingInterval `json:"pollingInterval"`
 	NotifyOnFailure                 bool                     `json:"notifyOnFailure"`
 	TriggerActionsOnNewEntitiesOnly bool                     `json:"triggerActionsOnNewEntitiesOnly"`
+	RemediationSteps                string                   `json:"remediationSteps"`
 }
 
 // GetQuestionId returns CreateReferencedQuestionRuleInstanceInput.QuestionId, and is useful for accessing the field via an interface.
@@ -528,6 +535,11 @@ func (v *CreateReferencedQuestionRuleInstanceInput) GetNotifyOnFailure() bool {
 // GetTriggerActionsOnNewEntitiesOnly returns CreateReferencedQuestionRuleInstanceInput.TriggerActionsOnNewEntitiesOnly, and is useful for accessing the field via an interface.
 func (v *CreateReferencedQuestionRuleInstanceInput) GetTriggerActionsOnNewEntitiesOnly() bool {
 	return v.TriggerActionsOnNewEntitiesOnly
+}
+
+// GetRemediationSteps returns CreateReferencedQuestionRuleInstanceInput.RemediationSteps, and is useful for accessing the field via an interface.
+func (v *CreateReferencedQuestionRuleInstanceInput) GetRemediationSteps() string {
+	return v.RemediationSteps
 }
 
 // CreateReferencedQuestionRuleInstanceResponse is returned by CreateReferencedQuestionRuleInstance on success.
@@ -1186,14 +1198,15 @@ func (v *RuleStateInput) GetActions() map[string]interface{} { return v.Actions 
 type SchedulerPollingInterval string
 
 const (
-	SchedulerPollingIntervalDisabled      SchedulerPollingInterval = "DISABLED"
-	SchedulerPollingIntervalThirtyMinutes SchedulerPollingInterval = "THIRTY_MINUTES"
-	SchedulerPollingIntervalOneHour       SchedulerPollingInterval = "ONE_HOUR"
-	SchedulerPollingIntervalFourHours     SchedulerPollingInterval = "FOUR_HOURS"
-	SchedulerPollingIntervalEightHours    SchedulerPollingInterval = "EIGHT_HOURS"
-	SchedulerPollingIntervalTwelveHours   SchedulerPollingInterval = "TWELVE_HOURS"
-	SchedulerPollingIntervalOneDay        SchedulerPollingInterval = "ONE_DAY"
-	SchedulerPollingIntervalOneWeek       SchedulerPollingInterval = "ONE_WEEK"
+	SchedulerPollingIntervalDisabled       SchedulerPollingInterval = "DISABLED"
+	SchedulerPollingIntervalFifteenMinutes SchedulerPollingInterval = "FIFTEEN_MINUTES"
+	SchedulerPollingIntervalThirtyMinutes  SchedulerPollingInterval = "THIRTY_MINUTES"
+	SchedulerPollingIntervalOneHour        SchedulerPollingInterval = "ONE_HOUR"
+	SchedulerPollingIntervalFourHours      SchedulerPollingInterval = "FOUR_HOURS"
+	SchedulerPollingIntervalEightHours     SchedulerPollingInterval = "EIGHT_HOURS"
+	SchedulerPollingIntervalTwelveHours    SchedulerPollingInterval = "TWELVE_HOURS"
+	SchedulerPollingIntervalOneDay         SchedulerPollingInterval = "ONE_DAY"
+	SchedulerPollingIntervalOneWeek        SchedulerPollingInterval = "ONE_WEEK"
 )
 
 type UpdateComplianceFrameworkFields struct {
@@ -1434,6 +1447,7 @@ type UpdateInlineQuestionRuleInstanceInput struct {
 	PollingInterval                 SchedulerPollingInterval `json:"pollingInterval"`
 	NotifyOnFailure                 bool                     `json:"notifyOnFailure"`
 	TriggerActionsOnNewEntitiesOnly bool                     `json:"triggerActionsOnNewEntitiesOnly"`
+	RemediationSteps                string                   `json:"remediationSteps,omitempty"`
 }
 
 // GetQuestion returns UpdateInlineQuestionRuleInstanceInput.Question, and is useful for accessing the field via an interface.
@@ -1489,6 +1503,11 @@ func (v *UpdateInlineQuestionRuleInstanceInput) GetNotifyOnFailure() bool { retu
 // GetTriggerActionsOnNewEntitiesOnly returns UpdateInlineQuestionRuleInstanceInput.TriggerActionsOnNewEntitiesOnly, and is useful for accessing the field via an interface.
 func (v *UpdateInlineQuestionRuleInstanceInput) GetTriggerActionsOnNewEntitiesOnly() bool {
 	return v.TriggerActionsOnNewEntitiesOnly
+}
+
+// GetRemediationSteps returns UpdateInlineQuestionRuleInstanceInput.RemediationSteps, and is useful for accessing the field via an interface.
+func (v *UpdateInlineQuestionRuleInstanceInput) GetRemediationSteps() string {
+	return v.RemediationSteps
 }
 
 // UpdateInlineQuestionRuleInstanceResponse is returned by UpdateInlineQuestionRuleInstance on success.
@@ -1557,6 +1576,7 @@ type UpdateReferencedQuestionRuleInstanceInput struct {
 	PollingInterval                 SchedulerPollingInterval `json:"pollingInterval"`
 	NotifyOnFailure                 bool                     `json:"notifyOnFailure"`
 	TriggerActionsOnNewEntitiesOnly bool                     `json:"triggerActionsOnNewEntitiesOnly"`
+	RemediationSteps                string                   `json:"remediationSteps"`
 }
 
 // GetQuestionId returns UpdateReferencedQuestionRuleInstanceInput.QuestionId, and is useful for accessing the field via an interface.
@@ -1612,6 +1632,11 @@ func (v *UpdateReferencedQuestionRuleInstanceInput) GetNotifyOnFailure() bool {
 // GetTriggerActionsOnNewEntitiesOnly returns UpdateReferencedQuestionRuleInstanceInput.TriggerActionsOnNewEntitiesOnly, and is useful for accessing the field via an interface.
 func (v *UpdateReferencedQuestionRuleInstanceInput) GetTriggerActionsOnNewEntitiesOnly() bool {
 	return v.TriggerActionsOnNewEntitiesOnly
+}
+
+// GetRemediationSteps returns UpdateReferencedQuestionRuleInstanceInput.RemediationSteps, and is useful for accessing the field via an interface.
+func (v *UpdateReferencedQuestionRuleInstanceInput) GetRemediationSteps() string {
+	return v.RemediationSteps
 }
 
 // UpdateReferencedQuestionRuleInstanceResponse is returned by UpdateReferencedQuestionRuleInstance on success.

--- a/jupiterone/internal/client/rule.graphql
+++ b/jupiterone/internal/client/rule.graphql
@@ -82,6 +82,7 @@ mutation CreateReferencedQuestionRuleInstance(
 # @genqlient(for: "UpdateInlineQuestionRuleInstanceInput.latestAlertId", omitempty: true)
 # @genqlient(for: "UpdateInlineQuestionRuleInstanceInput.outputs", omitempty: true)
 # @genqlient(for: "UpdateInlineQuestionRuleInstanceInput.state", omitempty: true)
+# @genqlient(for: "UpdateInlineQuestionRuleInstanceInput.remediationSteps", omitempty: true)
 mutation UpdateInlineQuestionRuleInstance(
   $instance: UpdateInlineQuestionRuleInstanceInput!
 ) {

--- a/jupiterone/modifiers_test.go
+++ b/jupiterone/modifiers_test.go
@@ -1,0 +1,68 @@
+package jupiterone
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJsonIgnoreDiffModifierList(t *testing.T) {
+	// This test is to isolate the jsonIgnoreDiff logic that is exercised
+	// the the resource_framework_test.go.
+	ctx := context.TODO()
+
+	testCases := []struct {
+		name         string
+		configValue  types.List
+		planValue    types.List
+		stateValue   types.List
+		expectedPlan types.List
+	}{
+		{
+			name:         "all_null",
+			configValue:  types.ListNull(types.StringType),
+			planValue:    types.ListNull(types.StringType),
+			stateValue:   types.ListNull(types.StringType),
+			expectedPlan: types.ListNull(types.StringType),
+		},
+		{
+			name:         "empty_plan_null_state",
+			configValue:  types.ListValueMust(types.StringType, []attr.Value{}),
+			planValue:    types.ListValueMust(types.StringType, []attr.Value{}),
+			stateValue:   types.ListNull(types.StringType),
+			expectedPlan: types.ListValueMust(types.StringType, []attr.Value{}),
+		},
+		{
+			name:         "empty_state_null_plan",
+			configValue:  types.ListNull(types.StringType),
+			planValue:    types.ListNull(types.StringType),
+			stateValue:   types.ListValueMust(types.StringType, []attr.Value{}),
+			expectedPlan: types.ListValueMust(types.StringType, []attr.Value{}),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			req := planmodifier.ListRequest{
+				ConfigValue: tt.configValue,
+				PlanValue:   tt.planValue,
+				StateValue:  tt.stateValue,
+			}
+			resp := &planmodifier.ListResponse{
+				PlanValue: tt.planValue,
+			}
+
+			mod := &jsonIgnoreDiff{}
+
+			mod.PlanModifyList(ctx, req, resp)
+
+			assert.False(t, resp.Diagnostics.HasError())
+			assert.Equal(t, tt.expectedPlan, resp.PlanValue)
+		})
+	}
+
+}

--- a/jupiterone/resource_framework_test.go
+++ b/jupiterone/resource_framework_test.go
@@ -30,6 +30,26 @@ func TestFramework_Basic(t *testing.T) {
 		CheckDestroy:             testAccCheckFrameworkDestroy(ctx, directClient),
 		Steps: []resource.TestStep{
 			{
+				Config: testFrameworkBasicConfig(updatedName, "[]"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(ctx, directClient),
+					resource.TestCheckResourceAttrSet(testFrameworkResourceName, "id"),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "version", "v1"),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "scope_filters.#", "0"),
+				),
+			},
+			{
+				Config: testFrameworkNoFiltersConfig(testFrameworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(ctx, directClient),
+					resource.TestCheckResourceAttrSet(testFrameworkResourceName, "id"),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "name", testFrameworkName),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "version", "v1"),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "scope_filters.#", "0"),
+				),
+			},
+			{
 				Config: testFrameworkBasicConfig(testFrameworkName, testEnvScopeFilters),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, directClient),
@@ -37,6 +57,26 @@ func TestFramework_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testFrameworkResourceName, "name", testFrameworkName),
 					resource.TestCheckResourceAttr(testFrameworkResourceName, "version", "v1"),
 					resource.TestCheckResourceAttr(testFrameworkResourceName, "scope_filters.#", "1"),
+				),
+			},
+			{
+				Config: testFrameworkBasicConfig(updatedName, "[]"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(ctx, directClient),
+					resource.TestCheckResourceAttrSet(testFrameworkResourceName, "id"),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "version", "v1"),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "scope_filters.#", "0"),
+				),
+			},
+			{
+				Config: testFrameworkNoFiltersConfig(testFrameworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(ctx, directClient),
+					resource.TestCheckResourceAttrSet(testFrameworkResourceName, "id"),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "name", testFrameworkName),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "version", "v1"),
+					resource.TestCheckResourceAttr(testFrameworkResourceName, "scope_filters.#", "0"),
 				),
 			},
 			{
@@ -139,4 +179,19 @@ func testFrameworkBasicConfig(name, scopeFilters string) string {
 	}
 	`,
 		name, scopeFilters)
+}
+
+func testFrameworkNoFiltersConfig(name string) string {
+	return fmt.Sprintf(`
+	provider "jupiterone" {}
+
+	resource "jupiterone_framework" "test" {
+		name           = %q
+		version        = "v1"
+		framework_type = "STANDARD"
+
+		web_link = "https://community.askj1.com/kb/articles/795-compliance-api-endpoints"
+	}
+	`,
+		name)
 }

--- a/jupiterone/resource_frameworkitem.go
+++ b/jupiterone/resource_frameworkitem.go
@@ -80,6 +80,9 @@ func (*ComplianceFrameworkItemResource) Schema(_ context.Context, _ resource.Sch
 			"framework_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The internal ID of the framework this item belongs to",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"group_id": schema.StringAttribute{
 				Required:    true,

--- a/jupiterone/resource_rule.go
+++ b/jupiterone/resource_rule.go
@@ -351,14 +351,6 @@ func (*QuestionRuleResource) ModifyPlan(ctx context.Context, req resource.Modify
 		return
 	}
 
-	// switching from referenced to inline requires replacement
-	if plan.QuestionId.IsNull() && !state.QuestionId.IsNull() {
-		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("question_id"))
-	}
-	if len(plan.Question) == 0 && len(state.Question) != 0 {
-		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("question"))
-	}
-
 	if !reflect.DeepEqual(plan, state) {
 		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("version"),
 			types.Int64Unknown())...)

--- a/jupiterone/resource_rule.go
+++ b/jupiterone/resource_rule.go
@@ -186,17 +186,17 @@ func (*QuestionRuleResource) Schema(ctx context.Context, req resource.SchemaRequ
 			},
 			"spec_version": schema.Int64Attribute{
 				Description: "Rule evaluation specification version in the case of breaking changes.",
-				Computed:    true,
-				Optional:    true,
 				Default:     int64default.StaticInt64(1),
+				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"polling_interval": schema.StringAttribute{
 				Description: "Frequency of automated rule evaluation. Defaults to ONE_DAY.",
-				Computed:    true,
 				Optional:    true,
+				Computed:    true,
 				Default:     stringdefault.StaticString(string(client.SchedulerPollingIntervalOneDay)),
 				Validators: []validator.String{
 					stringvalidator.OneOf(PollingIntervals...),
@@ -351,6 +351,14 @@ func (*QuestionRuleResource) ModifyPlan(ctx context.Context, req resource.Modify
 		return
 	}
 
+	// switching from referenced to inline requires replacement
+	if plan.QuestionId.IsNull() && !state.QuestionId.IsNull() {
+		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("question_id"))
+	}
+	if len(plan.Question) == 0 && len(state.Question) != 0 {
+		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("question"))
+	}
+
 	if !reflect.DeepEqual(plan, state) {
 		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("version"),
 			types.Int64Unknown())...)
@@ -474,6 +482,8 @@ func (r *QuestionRuleResource) Read(ctx context.Context, req resource.ReadReques
 
 	if rule.QuestionId != "" {
 		data.QuestionId = types.StringValue(rule.QuestionId)
+	} else {
+		data.QuestionId = types.StringNull()
 	}
 	if queries := rule.Question.Queries; len(queries) > 0 {
 		data.Question = []*RuleQuestion{{Queries: []*J1QueryInputModel{
@@ -484,6 +494,8 @@ func (r *QuestionRuleResource) Read(ctx context.Context, req resource.ReadReques
 				IncludedDeleted: queries[0].IncludeDeleted,
 			},
 		}}}
+	} else {
+		data.Question = nil
 	}
 
 	data.Operations, err = newOperationsWithoutId(rule.Operations)

--- a/jupiterone/resource_rule_test.go
+++ b/jupiterone/resource_rule_test.go
@@ -171,22 +171,6 @@ func TestReferencedQuestionRule_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair("jupiterone_question.test", "id", testRuleResourceName, "question_id"),
 				),
 			},
-			{
-				Config: testInlineRuleInstanceBasicConfigWithOperations(ruleName, operationsUpdate),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRuleExists(ctx, testRuleResourceName, directClient),
-					resource.TestCheckResourceAttr(testRuleResourceName, "question.#", "1"),
-					resource.TestCheckNoResourceAttr(testRuleResourceName, "question_id"),
-				),
-			},
-			{
-				Config: testReferencedRuleInstanceBasicConfigWithOperations(ruleName, operationsUpdate),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRuleExists(ctx, testRuleResourceName, directClient),
-					resource.TestCheckResourceAttr(testRuleResourceName, "question.#", "0"),
-					resource.TestCheckResourceAttrPair("jupiterone_question.test", "id", testRuleResourceName, "question_id"),
-				),
-			},
 		},
 	})
 }


### PR DESCRIPTION
This PR:

- Adds `RequireReplace` for framework item relations to help with deletion. This doesn't guarantee that framework items will be deleted first, but helps with the common use cases where they directly reference `resource_framework`s in the same workspace.
- ~~Switching back and forth between `Referenced` and `Inline` questions is resulting in some inconsistent behavior, so added a check and setting `RequiresReplace` to be more predictable.~~
- Makes `scope_filters` `Computed` as the most straightforward way to allow it being unset (`nil`) to not generate changes when the response from the server (b/c of how graphql works) is an empty list (`[]`).