### PR TITLE
Remove error check on casting to string array

### DIFF
--- a/jupiterone/modifiers.go
+++ b/jupiterone/modifiers.go
@@ -355,15 +355,7 @@ func (v jsonValidator) ValidateString(ctx context.Context, req validator.StringR
 // ValidateList implements validator.List
 func (v jsonValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
 	var vals []string
-	err := req.ConfigValue.ElementsAs(ctx, &vals, false)
-	if err != nil {
-		resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
-			req.Path,
-			"not a valid string: "+v.Description(ctx),
-			req.ConfigValue.String(),
-		))
-		return
-	}
+	req.ConfigValue.ElementsAs(ctx, &vals, false)
 
 	for _, s := range vals {
 		var d interface{}


### PR DESCRIPTION
Ticket - https://jupiterone.atlassian.net/browse/TRIAGE-1972

[Logic explaining](https://github.com/hashicorp/terraform/issues/28104#issuecomment-800423914) how variables are `unknown` at validate time and hence why the `ElementsAs` was erroring out when using a variable in the list.

Just to make the review easier. The issue was caused because prior to running a terraform plan, terraform runs a validate. During the validate step, variables are not processed but are treated as unknown. In the validate logic we were using validator.ListRequest.ElementsAs which casts from list type to target type and target was a string[]. Because the variable was of type `unknown` it was erroring out when trying to cast to string.