### PR TITLE
Changing list validator to use built in instead of custom validation

### DIFF
--- a/jupiterone/modifiers.go
+++ b/jupiterone/modifiers.go
@@ -313,7 +313,8 @@ func (apm *stringDefaultValuePlanModifier) PlanModifyString(ctx context.Context,
 }
 
 var _ validator.String = jsonValidator{}
-var _ validator.List = jsonValidator{}
+
+// var _ validator.List = jsonValidator{}
 var _ validator.Map = jsonValidator{}
 
 // oneOfValidator validates that the value matches one of expected values.
@@ -353,30 +354,9 @@ func (v jsonValidator) ValidateString(ctx context.Context, req validator.StringR
 }
 
 // ValidateList implements validator.List
-func (v jsonValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
-	var vals []string
-	err := req.ConfigValue.ElementsAs(ctx, &vals, false)
-	if err != nil {
-		resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
-			req.Path,
-			"not a valid string: "+v.Description(ctx),
-			req.ConfigValue.String(),
-		))
-		return
-	}
-
-	for _, s := range vals {
-		var d interface{}
-		err := json.Unmarshal([]byte(s), &d)
-		if err != nil {
-			resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
-				req.Path,
-				v.Description(ctx),
-				req.ConfigValue.String(),
-			))
-		}
-	}
-}
+// func (v jsonValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+// 	//
+// }
 
 // ValidateMap implements validator.Map
 func (v jsonValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {

--- a/jupiterone/modifiers.go
+++ b/jupiterone/modifiers.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -310,70 +309,4 @@ func (apm *stringDefaultValuePlanModifier) PlanModifyString(ctx context.Context,
 	}
 
 	res.PlanValue = apm.DefaultValue
-}
-
-var _ validator.String = jsonValidator{}
-
-var _ validator.Map = jsonValidator{}
-
-// oneOfValidator validates that the value matches one of expected values.
-type jsonValidator struct {
-}
-
-// Description implements validator.String
-func (jsonValidator) Description(context.Context) string {
-	return "string value must be valid JSON"
-}
-
-// MarkdownDescription implements validator.String
-func (v jsonValidator) MarkdownDescription(ctx context.Context) string {
-	return v.Description(ctx)
-}
-
-// ValidateString implements validator.String
-func (v jsonValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
-	if req.ConfigValue.IsUnknown() {
-		return
-	}
-
-	// TODO: check if optional?
-	if req.ConfigValue.IsNull() {
-		return
-	}
-
-	var d interface{}
-	err := json.Unmarshal([]byte(req.ConfigValue.ValueString()), &d)
-	if err != nil {
-		resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
-			req.Path,
-			v.Description(ctx),
-			req.ConfigValue.String(),
-		))
-	}
-}
-
-// ValidateList implements validator.List
-
-// ValidateMap implements validator.Map
-func (v jsonValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
-	for _, val := range req.ConfigValue.Elements() {
-		s, ok := val.(types.String)
-		if !ok {
-			resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
-				req.Path,
-				v.Description(ctx),
-				val.String(),
-			))
-		}
-
-		var d interface{}
-		err := json.Unmarshal([]byte(s.ValueString()), &d)
-		if err != nil {
-			resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
-				req.Path,
-				v.Description(ctx),
-				req.ConfigValue.String(),
-			))
-		}
-	}
 }

--- a/jupiterone/modifiers.go
+++ b/jupiterone/modifiers.go
@@ -353,9 +353,6 @@ func (v jsonValidator) ValidateString(ctx context.Context, req validator.StringR
 }
 
 // ValidateList implements validator.List
-// func (v jsonValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
-// 	//
-// }
 
 // ValidateMap implements validator.Map
 func (v jsonValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {

--- a/jupiterone/modifiers.go
+++ b/jupiterone/modifiers.go
@@ -314,7 +314,6 @@ func (apm *stringDefaultValuePlanModifier) PlanModifyString(ctx context.Context,
 
 var _ validator.String = jsonValidator{}
 
-// var _ validator.List = jsonValidator{}
 var _ validator.Map = jsonValidator{}
 
 // oneOfValidator validates that the value matches one of expected values.

--- a/jupiterone/resource_framework.go
+++ b/jupiterone/resource_framework.go
@@ -131,8 +131,8 @@ func (*ComplianceFrameworkResource) Schema(_ context.Context, _ resource.SchemaR
 				Description: "JSON encoded filters for scoping the framework.",
 				Optional:    true,
 				ElementType: types.StringType,
-				Validators: []validator.List{
-					jsonValidator{},
+				Validators:  []validator.List{
+					// jsonValidator{},
 				},
 				PlanModifiers: []planmodifier.List{
 					jsonIgnoreDiffPlanModifierList(),

--- a/jupiterone/resource_framework.go
+++ b/jupiterone/resource_framework.go
@@ -131,8 +131,7 @@ func (*ComplianceFrameworkResource) Schema(_ context.Context, _ resource.SchemaR
 				Description: "JSON encoded filters for scoping the framework.",
 				Optional:    true,
 				ElementType: types.StringType,
-				Validators:  []validator.List{
-				},
+				Validators:  []validator.List{},
 				PlanModifiers: []planmodifier.List{
 					jsonIgnoreDiffPlanModifierList(),
 				},

--- a/jupiterone/resource_framework.go
+++ b/jupiterone/resource_framework.go
@@ -132,7 +132,6 @@ func (*ComplianceFrameworkResource) Schema(_ context.Context, _ resource.SchemaR
 				Optional:    true,
 				ElementType: types.StringType,
 				Validators:  []validator.List{
-					// jsonValidator{},
 				},
 				PlanModifiers: []planmodifier.List{
 					jsonIgnoreDiffPlanModifierList(),

--- a/jupiterone/resource_rule.go
+++ b/jupiterone/resource_rule.go
@@ -228,9 +228,7 @@ func (*QuestionRuleResource) Schema(ctx context.Context, req resource.SchemaRequ
 						"actions": schema.ListAttribute{
 							Required:    true,
 							ElementType: types.StringType,
-							Validators: []validator.List{
-								jsonValidator{},
-							},
+							Validators:  []validator.List{},
 							PlanModifiers: []planmodifier.List{
 								jsonIgnoreDiffPlanModifierList(),
 							},

--- a/jupiterone/resource_rule.go
+++ b/jupiterone/resource_rule.go
@@ -219,7 +219,6 @@ func (*QuestionRuleResource) Schema(ctx context.Context, req resource.SchemaRequ
 							Optional: true,
 							Validators: []validator.String{
 								stringvalidator.LengthAtLeast(MIN_JSON_LENGTH),
-								jsonValidator{},
 							},
 							PlanModifiers: []planmodifier.String{
 								jsonIgnoreDiffPlanModifier(),


### PR DESCRIPTION
Removed all custom validator logic as we either weren't using it (in the case of `ValidateMap`) or it was performing duplicate work. The built-in validator will validate the schema when you pass in in the validator type `[]validator.String{}` or `[]validator.List{}`, and the work we were doing in the custom validator was essentially duplicating that work.

Relevant GitHub discussion for variable interpolation: https://github.com/hashicorp/terraform/issues/28104#issuecomment-800423914
