### PR TITLE
Use Default values as supported by newer terraform-plugin-framework

### DIFF
--- a/jupiterone/modifiers.go
+++ b/jupiterone/modifiers.go
@@ -11,41 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func BoolDefaultValuePlanModifier(b bool) planmodifier.Bool {
-	return &boolDefaultValuePlanModifier{
-		DefaultValue: types.BoolValue(b),
-	}
-}
-
-type boolDefaultValuePlanModifier struct {
-	DefaultValue types.Bool
-}
-
-var _ planmodifier.Bool = (*boolDefaultValuePlanModifier)(nil)
-
-func (pm *boolDefaultValuePlanModifier) Description(ctx context.Context) string {
-	return "sets a default value for a bool value"
-}
-
-func (pm *boolDefaultValuePlanModifier) MarkdownDescription(ctx context.Context) string {
-	return pm.Description(ctx)
-}
-
-func (pm *boolDefaultValuePlanModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, res *planmodifier.BoolResponse) {
-	// If the attribute configuration is not null, we are done here
-	if !req.ConfigValue.IsNull() {
-		return
-	}
-
-	// If the attribute plan is "known" and "not null", then a previous plan modifier in the sequence
-	// has already been applied, and we don't want to interfere.
-	if !req.PlanValue.IsUnknown() && !req.PlanValue.IsNull() {
-		return
-	}
-
-	res.PlanValue = pm.DefaultValue
-}
-
 var _ planmodifier.String = (*jsonIgnoreDiff)(nil)
 var _ planmodifier.List = (*jsonIgnoreDiff)(nil)
 var _ planmodifier.Map = (*jsonIgnoreDiff)(nil)
@@ -239,74 +204,4 @@ func (jsonIgnoreDiff) PlanModifyMap(ctx context.Context, req planmodifier.MapReq
 	}
 
 	resp.PlanValue = req.StateValue
-}
-
-func Int64DefaultValue(v types.Int64) planmodifier.Int64 {
-	return &int64DefaultValuePlanModifier{v}
-}
-
-// int64DefaultValuePlanModifier is based on the example at:
-// https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/default-values
-type int64DefaultValuePlanModifier struct {
-	DefaultValue types.Int64
-}
-
-var _ planmodifier.Int64 = (*int64DefaultValuePlanModifier)(nil)
-
-func (apm *int64DefaultValuePlanModifier) Description(ctx context.Context) string {
-	return "sets a default value for an int64 value"
-}
-
-func (apm *int64DefaultValuePlanModifier) MarkdownDescription(ctx context.Context) string {
-	return apm.Description(ctx)
-}
-
-func (apm *int64DefaultValuePlanModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, res *planmodifier.Int64Response) {
-	// If the attribute configuration is not null, we are done here
-	if !req.ConfigValue.IsNull() {
-		return
-	}
-
-	// If the attribute plan is "known" and "not null", then a previous plan modifier in the sequence
-	// has already been applied, and we don't want to interfere.
-	if !req.PlanValue.IsUnknown() && !req.PlanValue.IsNull() {
-		return
-	}
-
-	res.PlanValue = apm.DefaultValue
-}
-
-func StringDefaultValue(v string) planmodifier.String {
-	return &stringDefaultValuePlanModifier{
-		DefaultValue: types.StringValue(v),
-	}
-}
-
-type stringDefaultValuePlanModifier struct {
-	DefaultValue types.String
-}
-
-var _ planmodifier.String = (*stringDefaultValuePlanModifier)(nil)
-
-func (apm *stringDefaultValuePlanModifier) Description(ctx context.Context) string {
-	return "sets a default value for an string value"
-}
-
-func (apm *stringDefaultValuePlanModifier) MarkdownDescription(ctx context.Context) string {
-	return apm.Description(ctx)
-}
-
-func (apm *stringDefaultValuePlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, res *planmodifier.StringResponse) {
-	// If the attribute configuration is not null, we are done here
-	if !req.ConfigValue.IsNull() {
-		return
-	}
-
-	// If the attribute plan is "known" and "not null", then a previous plan modifier in the sequence
-	// has already been applied, and we don't want to interfere.
-	if !req.PlanValue.IsUnknown() && !req.PlanValue.IsNull() {
-		return
-	}
-
-	res.PlanValue = apm.DefaultValue
 }

--- a/jupiterone/resource_question.go
+++ b/jupiterone/resource_question.go
@@ -104,9 +104,7 @@ func (*QuestionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Description: "Whether to enable daily trend data collection. Defaults to false.",
 				Optional:    true,
 				Computed:    true,
-				PlanModifiers: []planmodifier.Bool{
-					BoolDefaultValuePlanModifier(false),
-				},
+				Default:     booldefault.StaticBool(false),
 			},
 			"polling_interval": schema.StringAttribute{
 				Description: "Frequency of automated question evaluation. Defaults to ONE_DAY.",

--- a/jupiterone/resource_question.go
+++ b/jupiterone/resource_question.go
@@ -10,7 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -101,9 +103,7 @@ func (*QuestionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Description: "Frequency of automated question evaluation. Defaults to ONE_DAY.",
 				Computed:    true,
 				Optional:    true,
-				PlanModifiers: []planmodifier.String{
-					StringDefaultValue(string(client.SchedulerPollingIntervalOneDay)),
-				},
+				Default:     stringdefault.StaticString(string(client.SchedulerPollingIntervalOneDay)),
 				Validators: []validator.String{
 					stringvalidator.OneOf(PollingIntervals...),
 				},
@@ -140,17 +140,13 @@ func (*QuestionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						"include_deleted": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
-							PlanModifiers: []planmodifier.Bool{
-								BoolDefaultValuePlanModifier(false),
-							},
+							Default:  booldefault.StaticBool(false),
 						},
 						"results_are": schema.StringAttribute{
 							Description: "Defaults to INFORMATIVE.",
 							Computed:    true,
 							Optional:    true,
-							PlanModifiers: []planmodifier.String{
-								StringDefaultValue(string(client.QueryResultsAreInformative)),
-							},
+							Default:     stringdefault.StaticString(string(client.QueryResultsAreInformative)),
 							Validators: []validator.String{
 								stringvalidator.OneOf(QueryResultsAre...),
 							},

--- a/jupiterone/resource_rule.go
+++ b/jupiterone/resource_rule.go
@@ -13,8 +13,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -185,18 +188,16 @@ func (*QuestionRuleResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Description: "Rule evaluation specification version in the case of breaking changes.",
 				Computed:    true,
 				Optional:    true,
+				Default:     int64default.StaticInt64(1),
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
-					Int64DefaultValue(types.Int64Value(1)),
 				},
 			},
 			"polling_interval": schema.StringAttribute{
 				Description: "Frequency of automated rule evaluation. Defaults to ONE_DAY.",
 				Computed:    true,
 				Optional:    true,
-				PlanModifiers: []planmodifier.String{
-					StringDefaultValue(string(client.SchedulerPollingIntervalOneDay)),
-				},
+				Default:     stringdefault.StaticString(string(client.SchedulerPollingIntervalOneDay)),
 				Validators: []validator.String{
 					stringvalidator.OneOf(PollingIntervals...),
 				},
@@ -248,16 +249,12 @@ func (*QuestionRuleResource) Schema(ctx context.Context, req resource.SchemaRequ
 			"notify_on_failure": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					BoolDefaultValuePlanModifier(false),
-				},
+				Default:  booldefault.StaticBool(false),
 			},
 			"trigger_on_new_only": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					BoolDefaultValuePlanModifier(false),
-				},
+				Default:  booldefault.StaticBool(false),
 			},
 		},
 		// TODO: Deprecate the use of blocks following new framework guidance:
@@ -292,9 +289,7 @@ func (*QuestionRuleResource) Schema(ctx context.Context, req resource.SchemaRequ
 									"include_deleted": schema.BoolAttribute{
 										Optional: true,
 										Computed: true,
-										PlanModifiers: []planmodifier.Bool{
-											BoolDefaultValuePlanModifier(false),
-										},
+										Default:  booldefault.StaticBool(false),
 									},
 								},
 							},


### PR DESCRIPTION
The first releases of `terraform-plugin-framework` required the use of custom plan modifiers for default values, but now `Default` values are supported, so use those instead.