### PR TITLE
Add fix to not force widgetId to empty string

### DIFF
--- a/jupiterone/internal/client/generated.go
+++ b/jupiterone/internal/client/generated.go
@@ -392,6 +392,8 @@ type CreateQuestionCreateQuestion struct {
 // GetId returns CreateQuestionCreateQuestion.Id, and is useful for accessing the field via an interface.
 func (v *CreateQuestionCreateQuestion) GetId() string { return v.Id }
 
+// The question-service does not list questions when widgetId="", 
+// we need to set it to null to allow the questions to show up in the UI
 type CreateQuestionInput struct {
 	Title           string                            `json:"title"`
 	Name            string                            `json:"name"`
@@ -399,7 +401,7 @@ type CreateQuestionInput struct {
 	Description     string                            `json:"description"`
 	ShowTrend       bool                              `json:"showTrend"`
 	PollingInterval SchedulerPollingInterval          `json:"pollingInterval"`
-	WidgetId        string                            `json:"widgetId"`
+	WidgetId        string                            `json:"widgetId,omitempty"`
 	Queries         []QuestionQueryInput              `json:"queries"`
 	Compliance      []QuestionComplianceMetaDataInput `json:"compliance"`
 	Variables       []QuestionVariableInput           `json:"variables"`
@@ -1095,7 +1097,7 @@ type QuestionUpdate struct {
 	Description     string                            `json:"description"`
 	ShowTrend       bool                              `json:"showTrend"`
 	PollingInterval SchedulerPollingInterval          `json:"pollingInterval"`
-	WidgetId        string                            `json:"widgetId"`
+	WidgetId        string                            `json:"widgetId,omitempty"`
 }
 
 // GetTitle returns QuestionUpdate.Title, and is useful for accessing the field via an interface.


### PR DESCRIPTION
Add omitempty to stop the provider from setting widgetId to an empty string when no widgetId is provided.

Tested,

Before:
```
query Question(
    $id: ID!, 
    ) {
  question(
  ...

"data": {
        "question": {
            "__typename": "Question",
            "accountId": "j1dev",
            "queries": [
                {
                    "query": "FIND aws_instance WITH displayName~='wazuh1'",
                    "version": "1",
                    "resultsAre": "INFORMATIVE",
                    "includeDeleted": false,
                    "name": "query0"
                }
            ],
            "widgetId": "",
            "tags": null,
            "title": "1What are all wazuh related instances",
```

After:
```
query Question(
    $id: ID!, 
    ) {
  question(
...

"data": {
        "question": {
            "__typename": "Question",
            "accountId": "j1dev",
            "queries": [
                {
                    "query": "FIND aws_instance WITH displayName~='wazuh1'",
                    "version": "1",
                    "resultsAre": "INFORMATIVE",
                    "includeDeleted": false,
                    "name": "query0"
                }
            ],
            "widgetId": null,
            "tags": null,
            "title": "1What are all wazuh related instances",
```