### PR TITLE
Update GHA to remove deprecated flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2.7.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The goreleaser GHA has deprecated the `--rm-dist` flag - https://goreleaser.com/deprecations/#-rm-dist