### PR TITLE
Add go releaser version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
Adding version to the goreleaser file, [this was the error from the previous action run](https://github.com/JupiterOne/terraform-provider-jupiterone/actions/runs/9682339901/job/26715119134)
![image](https://github.com/JupiterOne/terraform-provider-jupiterone/assets/84300304/e532e808-e2c1-4ef4-89e1-69d98f3bd1fe)


Similar issue - https://github.com/goreleaser/goreleaser-action/issues/466