### PR TITLE
Change flag to supported flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,4 +45,4 @@ signs:
 release:
   draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
```
@crichts-MBP ➜ terraform-provider-jupiterone git:(fix-gha-3) ✗ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```

Ok, I've actually validated this config file is in the right format now so this should be the last one.