### PR TITLE
Resolve issue with description causing unexpected changes to be recorded

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See the [examples](./examples) directory
 1. Install [Go](https://go.dev/doc/install) and `make`
 1. Clone the repository
 1. Enter the repository directory
-1. Build the provider with `make build` or invoke `go install` directly.
+1. Build the provider with `make build` and then `go install. `
 1. Install the provider locally as referenced [here](#using-development-environment-provider-locally)
 
 ## Adding Dependencies

--- a/jupiterone/internal/client/generated.go
+++ b/jupiterone/internal/client/generated.go
@@ -700,10 +700,9 @@ func (v *CreateInsightsDashboardLayoutItem) GetY() int64 { return v.Y }
 func (v *CreateInsightsDashboardLayoutItem) GetI() string { return v.I }
 
 type CreateInsightsWidgetConfigInput struct {
-	Queries                   []CreateInsightsWidgetConfigQueryInput `json:"queries"`
-	Settings                  map[string]interface{}                 `json:"settings"`
-	PostQueryFilters          []string                               `json:"postQueryFilters"`
-	DisableQueryPolicyFilters bool                                   `json:"disableQueryPolicyFilters"`
+	Queries          []CreateInsightsWidgetConfigQueryInput `json:"queries"`
+	Settings         map[string]interface{}                 `json:"settings"`
+	PostQueryFilters []string                               `json:"postQueryFilters"`
 }
 
 // GetQueries returns CreateInsightsWidgetConfigInput.Queries, and is useful for accessing the field via an interface.
@@ -716,11 +715,6 @@ func (v *CreateInsightsWidgetConfigInput) GetSettings() map[string]interface{} {
 
 // GetPostQueryFilters returns CreateInsightsWidgetConfigInput.PostQueryFilters, and is useful for accessing the field via an interface.
 func (v *CreateInsightsWidgetConfigInput) GetPostQueryFilters() []string { return v.PostQueryFilters }
-
-// GetDisableQueryPolicyFilters returns CreateInsightsWidgetConfigInput.DisableQueryPolicyFilters, and is useful for accessing the field via an interface.
-func (v *CreateInsightsWidgetConfigInput) GetDisableQueryPolicyFilters() bool {
-	return v.DisableQueryPolicyFilters
-}
 
 type CreateInsightsWidgetConfigQueryInput struct {
 	Id    string `json:"id"`
@@ -4567,10 +4561,9 @@ func (v *Widget) GetNoResultMessage() string { return v.NoResultMessage }
 func (v *Widget) GetIncludeDeleted() bool { return v.IncludeDeleted }
 
 type WidgetConfig struct {
-	Queries                   []WidgetQuery          `json:"queries"`
-	Settings                  map[string]interface{} `json:"settings"`
-	PostQueryFilters          []string               `json:"postQueryFilters"`
-	DisableQueryPolicyFilters bool                   `json:"disableQueryPolicyFilters"`
+	Queries          []WidgetQuery          `json:"queries"`
+	Settings         map[string]interface{} `json:"settings"`
+	PostQueryFilters []string               `json:"postQueryFilters"`
 }
 
 // GetQueries returns WidgetConfig.Queries, and is useful for accessing the field via an interface.
@@ -4581,9 +4574,6 @@ func (v *WidgetConfig) GetSettings() map[string]interface{} { return v.Settings 
 
 // GetPostQueryFilters returns WidgetConfig.PostQueryFilters, and is useful for accessing the field via an interface.
 func (v *WidgetConfig) GetPostQueryFilters() []string { return v.PostQueryFilters }
-
-// GetDisableQueryPolicyFilters returns WidgetConfig.DisableQueryPolicyFilters, and is useful for accessing the field via an interface.
-func (v *WidgetConfig) GetDisableQueryPolicyFilters() bool { return v.DisableQueryPolicyFilters }
 
 type WidgetQuery struct {
 	Id    string `json:"id"`

--- a/jupiterone/resource_widget.go
+++ b/jupiterone/resource_widget.go
@@ -212,7 +212,11 @@ func (r *WidgetResource) Read(ctx context.Context, req resource.ReadRequest, res
 	// Map the widgetMap to WidgetModel
 	data.Id = types.StringValue(widgetMap["id"].(string))
 	data.Title = types.StringValue(widgetMap["title"].(string))
-	data.Description = types.StringValue(widgetMap["description"].(string))
+	if description, ok := widgetMap["description"].(string); ok && description != "" {
+		data.Description = types.StringValue(description)
+	} else {
+		data.Description = types.StringNull() // Always set to an empty string if null or empty
+	}
 	data.Type = types.StringValue(widgetMap["type"].(string))
 	data.Config = widgetConfig
 


### PR DESCRIPTION
Description is null in state but returns as an  empty string from the server. This would cause changes to be registered when nothing was actually different.