### PR TITLE
TD-6594: Update integration to skip referencing nil ingestionOverrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ schema.graphql
 # Terrform lock files from testing
 .terraform*
 !.terraform-registry
+
+supportLogs/

--- a/jupiterone/internal/client/generated.go
+++ b/jupiterone/internal/client/generated.go
@@ -542,7 +542,7 @@ type CreateInlineQuestionRuleInstanceCreateQuestionRuleInstance struct {
 	Version     int                                                                                   `json:"version"`
 	SpecVersion int                                                                                   `json:"specVersion"`
 	Question    CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceQuestionRuleQuestionDetails `json:"question"`
-	Operations  []RuleOperationOutput                                                                 `json:"operations"`
+	Operations  []CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceOperationsRuleOperation   `json:"operations"`
 	Labels      []CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceLabelsRuleInstanceLabel   `json:"labels"`
 }
 
@@ -565,7 +565,7 @@ func (v *CreateInlineQuestionRuleInstanceCreateQuestionRuleInstance) GetQuestion
 }
 
 // GetOperations returns CreateInlineQuestionRuleInstanceCreateQuestionRuleInstance.Operations, and is useful for accessing the field via an interface.
-func (v *CreateInlineQuestionRuleInstanceCreateQuestionRuleInstance) GetOperations() []RuleOperationOutput {
+func (v *CreateInlineQuestionRuleInstanceCreateQuestionRuleInstance) GetOperations() []CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceOperationsRuleOperation {
 	return v.Operations
 }
 
@@ -588,6 +588,22 @@ func (v *CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceLabelsRuleIns
 // GetLabelValue returns CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceLabelsRuleInstanceLabel.LabelValue, and is useful for accessing the field via an interface.
 func (v *CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceLabelsRuleInstanceLabel) GetLabelValue() string {
 	return v.LabelValue
+}
+
+// CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceOperationsRuleOperation includes the requested fields of the GraphQL type RuleOperation.
+type CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceOperationsRuleOperation struct {
+	When    interface{}   `json:"when"`
+	Actions []interface{} `json:"actions"`
+}
+
+// GetWhen returns CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceOperationsRuleOperation.When, and is useful for accessing the field via an interface.
+func (v *CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceOperationsRuleOperation) GetWhen() interface{} {
+	return v.When
+}
+
+// GetActions returns CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceOperationsRuleOperation.Actions, and is useful for accessing the field via an interface.
+func (v *CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceOperationsRuleOperation) GetActions() []interface{} {
+	return v.Actions
 }
 
 // CreateInlineQuestionRuleInstanceCreateQuestionRuleInstanceQuestionRuleQuestionDetails includes the requested fields of the GraphQL type RuleQuestionDetails.
@@ -4496,7 +4512,7 @@ type UpdateIntegrationInstanceInput struct {
 	Config                        interface{}                                   `json:"config"`
 	OffsiteComplete               bool                                          `json:"offsiteComplete,omitempty"`
 	CollectorPoolId               string                                        `json:"collectorPoolId,omitempty"`
-	IngestionSourcesOverrides     []IngestionSourcesOverridesInput              `json:"ingestionSourcesOverrides,omitempty"`
+	IngestionSourcesOverrides     []IngestionSourcesOverridesInput              `json:"ingestionSourcesOverrides"`
 	ResourceGroupId               string                                        `json:"resourceGroupId"`
 	UpdateChildResourceGroup      bool                                          `json:"updateChildResourceGroup"`
 }

--- a/jupiterone/internal/client/integration.graphql
+++ b/jupiterone/internal/client/integration.graphql
@@ -54,7 +54,6 @@ mutation CreateIntegrationInstance(
 # @genqlient(for: "UpdateIntegrationInstanceInput.collectorPoolId", omitempty: true)
 # @genqlient(for: "UpdateIntegrationInstanceInput.pollingIntervalCronExpression", omitempty: true)
 # @genqlient(for: "UpdateIntegrationInstanceInput.offsiteComplete", omitempty: true)
-# @genqlient(for: "UpdateIntegrationInstanceInput.ingestionSourcesOverrides", omitempty: true)
 mutation UpdateIntegrationInstance(
   $id: String!
   $update: UpdateIntegrationInstanceInput!

--- a/jupiterone/resource_integration.go
+++ b/jupiterone/resource_integration.go
@@ -185,7 +185,7 @@ func (r *IntegrationResource) Read(ctx context.Context, req resource.ReadRequest
 		data.PollingIntervalCronExpression = types.StringValue(string(cronExpressionJSON))
 	}
 
-	if len(response.IntegrationInstance.IngestionSourcesOverrides) > 0 {
+	if response.IntegrationInstance.IngestionSourcesOverrides != nil && len(response.IntegrationInstance.IngestionSourcesOverrides) > 0 {
 		converted := make([]IngestionSourceOverride, len(response.IntegrationInstance.IngestionSourcesOverrides))
 		for i, v := range response.IntegrationInstance.IngestionSourcesOverrides {
 			converted[i] = IngestionSourceOverride{
@@ -241,7 +241,7 @@ func (r *IntegrationResource) Update(ctx context.Context, req resource.UpdateReq
 		input.PollingIntervalCronExpression = cronExpression
 	}
 
-	if len(*data.IngestionSourcesOverrides) > 0 {
+	if data.IngestionSourcesOverrides != nil && len(*data.IngestionSourcesOverrides) > 0 {
 		converted := make([]client.IngestionSourcesOverridesInput, len(*data.IngestionSourcesOverrides))
 		for i, v := range *data.IngestionSourcesOverrides {
 			converted[i] = client.IngestionSourcesOverridesInput{

--- a/jupiterone/resource_integration.go
+++ b/jupiterone/resource_integration.go
@@ -185,7 +185,7 @@ func (r *IntegrationResource) Read(ctx context.Context, req resource.ReadRequest
 		data.PollingIntervalCronExpression = types.StringValue(string(cronExpressionJSON))
 	}
 
-	if response.IntegrationInstance.IngestionSourcesOverrides != nil && len(response.IntegrationInstance.IngestionSourcesOverrides) > 0 {
+	if len(response.IntegrationInstance.IngestionSourcesOverrides) > 0 {
 		converted := make([]IngestionSourceOverride, len(response.IntegrationInstance.IngestionSourcesOverrides))
 		for i, v := range response.IntegrationInstance.IngestionSourcesOverrides {
 			converted[i] = IngestionSourceOverride{
@@ -241,7 +241,7 @@ func (r *IntegrationResource) Update(ctx context.Context, req resource.UpdateReq
 		input.PollingIntervalCronExpression = cronExpression
 	}
 
-	if data.IngestionSourcesOverrides != nil && len(*data.IngestionSourcesOverrides) > 0 {
+	if len(*data.IngestionSourcesOverrides) > 0 {
 		converted := make([]client.IngestionSourcesOverridesInput, len(*data.IngestionSourcesOverrides))
 		for i, v := range *data.IngestionSourcesOverrides {
 			converted[i] = client.IngestionSourcesOverridesInput{

--- a/jupiterone/resource_integration.go
+++ b/jupiterone/resource_integration.go
@@ -109,14 +109,16 @@ func (r *IntegrationResource) Create(ctx context.Context, req resource.CreateReq
 		input.PollingIntervalCronExpression = cronExpression
 	}
 
-	converted := make([]client.IngestionSourcesOverridesInput, len(*data.IngestionSourcesOverrides))
-	for i, v := range *data.IngestionSourcesOverrides {
-		converted[i] = client.IngestionSourcesOverridesInput{
-			IngestionSourceId: v.IngestionSourceId,
-			Enabled:           v.Enabled,
+	if data.IngestionSourcesOverrides != nil {
+		converted := make([]client.IngestionSourcesOverridesInput, len(*data.IngestionSourcesOverrides))
+		for i, v := range *data.IngestionSourcesOverrides {
+			converted[i] = client.IngestionSourcesOverridesInput{
+				IngestionSourceId: v.IngestionSourceId,
+				Enabled:           v.Enabled,
+			}
 		}
+		input.IngestionSourcesOverrides = converted
 	}
-	input.IngestionSourcesOverrides = converted
 
 	if !data.ResourceGroupId.IsNull() {
 		input.ResourceGroupId = data.ResourceGroupId.ValueString()
@@ -183,14 +185,18 @@ func (r *IntegrationResource) Read(ctx context.Context, req resource.ReadRequest
 		data.PollingIntervalCronExpression = types.StringValue(string(cronExpressionJSON))
 	}
 
-	converted := make([]IngestionSourceOverride, len(response.IntegrationInstance.IngestionSourcesOverrides))
-	for i, v := range response.IntegrationInstance.IngestionSourcesOverrides {
-		converted[i] = IngestionSourceOverride{
-			IngestionSourceId: v.IngestionSourceId,
-			Enabled:           v.Enabled,
+	if response.IntegrationInstance.IngestionSourcesOverrides != nil && len(response.IntegrationInstance.IngestionSourcesOverrides) > 0 {
+		converted := make([]IngestionSourceOverride, len(response.IntegrationInstance.IngestionSourcesOverrides))
+		for i, v := range response.IntegrationInstance.IngestionSourcesOverrides {
+			converted[i] = IngestionSourceOverride{
+				IngestionSourceId: v.IngestionSourceId,
+				Enabled:           v.Enabled,
+			}
 		}
+		data.IngestionSourcesOverrides = &converted
+	} else {
+		data.IngestionSourcesOverrides = nil
 	}
-	data.IngestionSourcesOverrides = &converted
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -235,14 +241,18 @@ func (r *IntegrationResource) Update(ctx context.Context, req resource.UpdateReq
 		input.PollingIntervalCronExpression = cronExpression
 	}
 
-	converted := make([]client.IngestionSourcesOverridesInput, len(*data.IngestionSourcesOverrides))
-	for i, v := range *data.IngestionSourcesOverrides {
-		converted[i] = client.IngestionSourcesOverridesInput{
-			IngestionSourceId: v.IngestionSourceId,
-			Enabled:           v.Enabled,
+	if data.IngestionSourcesOverrides != nil && len(*data.IngestionSourcesOverrides) > 0 {
+		converted := make([]client.IngestionSourcesOverridesInput, len(*data.IngestionSourcesOverrides))
+		for i, v := range *data.IngestionSourcesOverrides {
+			converted[i] = client.IngestionSourcesOverridesInput{
+				IngestionSourceId: v.IngestionSourceId,
+				Enabled:           v.Enabled,
+			}
 		}
+		input.IngestionSourcesOverrides = converted
+	} else {
+		input.IngestionSourcesOverrides = []client.IngestionSourcesOverridesInput{}
 	}
-	input.IngestionSourcesOverrides = converted
 
 	if !data.ResourceGroupId.IsNull() {
 		input.ResourceGroupId = data.ResourceGroupId.ValueString()

--- a/jupiterone/resource_integration.go
+++ b/jupiterone/resource_integration.go
@@ -185,7 +185,7 @@ func (r *IntegrationResource) Read(ctx context.Context, req resource.ReadRequest
 		data.PollingIntervalCronExpression = types.StringValue(string(cronExpressionJSON))
 	}
 
-	if response.IntegrationInstance.IngestionSourcesOverrides != nil && len(response.IntegrationInstance.IngestionSourcesOverrides) > 0 {
+	if len(response.IntegrationInstance.IngestionSourcesOverrides) > 0 {
 		converted := make([]IngestionSourceOverride, len(response.IntegrationInstance.IngestionSourcesOverrides))
 		for i, v := range response.IntegrationInstance.IngestionSourcesOverrides {
 			converted[i] = IngestionSourceOverride{


### PR DESCRIPTION
Customer is getting an error about a nil pointer because of a recent change that went out around IngestionSourcesOverrides. We now check if the property is nil before assessing its length.

Also found another bug while testing this one where user could not remove an array of IngestionSourcesOverrides. This was because of the omit empty flag on the property.