### PR TITLE
fix: omit empty updateMode in UpdateIntegrationInstanceInput (v1.18.0 regression)

### DIFF
--- a/jupiterone/internal/client/generated.go
+++ b/jupiterone/internal/client/generated.go
@@ -6559,7 +6559,7 @@ type UpdateIntegrationInstanceInput struct {
 	IngestionSourcesOverrides     []IngestionSourcesOverridesInput              `json:"ingestionSourcesOverrides,omitempty"`
 	ResourceGroupId               string                                        `json:"resourceGroupId"`
 	UpdateChildResourceGroup      bool                                          `json:"updateChildResourceGroup"`
-	UpdateMode                    UpdateConfigMode                              `json:"updateMode"`
+	UpdateMode                    UpdateConfigMode                              `json:"updateMode,omitempty"`
 }
 
 // GetName returns UpdateIntegrationInstanceInput.Name, and is useful for accessing the field via an interface.

--- a/jupiterone/internal/client/integration.graphql
+++ b/jupiterone/internal/client/integration.graphql
@@ -55,6 +55,7 @@ mutation CreateIntegrationInstance(
 # @genqlient(for: "UpdateIntegrationInstanceInput.pollingIntervalCronExpression", omitempty: true)
 # @genqlient(for: "UpdateIntegrationInstanceInput.offsiteComplete", omitempty: true)
 # @genqlient(for: "UpdateIntegrationInstanceInput.ingestionSourcesOverrides", omitempty: true)
+# @genqlient(for: "UpdateIntegrationInstanceInput.updateMode", omitempty: true)
 mutation UpdateIntegrationInstance(
   $id: String!
   $update: UpdateIntegrationInstanceInput!

--- a/jupiterone/internal/client/integration_input_test.go
+++ b/jupiterone/internal/client/integration_input_test.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// When the integration resource updates an instance it does not set UpdateMode.
+// The field is an enum (UpdateConfigMode) whose only valid values are MERGE and
+// PARTIAL_REPLACE, so the empty zero value must be omitted from the request or
+// the API rejects it with:
+//
+//	Value "" does not exist in "UpdateConfigMode" enum.
+//
+// Regression test for the v1.18.0 breakage of jupiterone_integration updates.
+func TestUpdateIntegrationInstanceInputOmitsEmptyUpdateMode(t *testing.T) {
+	input := UpdateIntegrationInstanceInput{
+		Name:            "example",
+		PollingInterval: IntegrationPollingIntervalThirtyMinutes,
+		Description:     "example",
+		Config:          map[string]interface{}{"foo": "bar"},
+	}
+
+	b, err := json.Marshal(input)
+	assert.NoError(t, err)
+
+	assert.NotContains(t, string(b), `"updateMode":""`,
+		"an unset updateMode must be omitted so the API does not reject the empty enum value")
+}


### PR DESCRIPTION
## Problem

v1.18.0 broke `terraform apply` for any existing `jupiterone_integration` resource:

```
400 Bad Request: Variable "$update" got invalid value "" at "update.updateMode";
Value "" does not exist in "UpdateConfigMode" enum.
```

Creates were unaffected; only updates failed.

## Root cause

v1.18.0 regenerated the GraphQL client from a schema that newly added `updateMode` to `UpdateIntegrationInstanceInput`. Every other optional field on that input carries a `@genqlient(..., omitempty: true)` directive in `integration.graphql`, but `updateMode` was missed — so it generated **without** `,omitempty`:

```go
UpdateMode UpdateConfigMode `json:"updateMode"`
```

The integration resource never sets `UpdateMode`, so every update marshaled `"updateMode":""`, and `""` is not a valid `UpdateConfigMode` (`MERGE` / `PARTIAL_REPLACE`). Creates are unaffected because `CreateIntegrationInstanceInput` has no `updateMode` field at all.

## Fix

Add the missing `omitempty` genqlient directive for the field and apply the matching change to `generated.go`:

```diff
+ # @genqlient(for: "UpdateIntegrationInstanceInput.updateMode", omitempty: true)
- UpdateMode UpdateConfigMode `json:"updateMode"`
+ UpdateMode UpdateConfigMode `json:"updateMode,omitempty"`
```

Omitting the unset field restores the exact pre-v1.18 wire behavior (the field was never sent), deferring to the server default rather than forcing a mode.

> The schema is fetched live (`scripts/get_current_schema.bash`) and isn't checked in, so a full `genqlient` regen would need account credentials and produce a large unrelated diff. The directive keeps the source of truth correct for the next regen; the `generated.go` edit is exactly what that regen emits.

## Testing

Added a regression test `TestUpdateIntegrationInstanceInputOmitsEmptyUpdateMode` that marshals the input the way the resource does (without `UpdateMode`) and asserts `"updateMode":""` is absent. Fails before the fix, passes after. Full `client` package tests pass; `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)